### PR TITLE
fix: Add missing dev dependencies to pyproject.toml

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -1,5 +1,5 @@
 # Instructions
 
-1. **Install Dependencies:** `pip install -e .`
+1. **Install Dependencies:** `pip install -e .[dev]`
 2. **Run Tests:** `pytest`
 3. **Check Score:** `agent-score . --agent=jules`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ requires-python = ">=3.8"
 
 [project.scripts]
 agent-score = "agent_scorecard.main:cli"
+
+[project.optional-dependencies]
+dev = ["pytest"]


### PR DESCRIPTION
Added [project.optional-dependencies] with 'pytest' to pyproject.toml to ensure dev installation works correctly. Also updated instructions.md to use 'pip install -e .[dev]'.

---
*PR created automatically by Jules for task [7394483987292183446](https://jules.google.com/task/7394483987292183446) started by @brewmarsh*