### PR TITLE
Add fix command and fix advise bug

### DIFF
--- a/src/agent_scorecard/main.py
+++ b/src/agent_scorecard/main.py
@@ -21,6 +21,23 @@ def cli():
     """Main entry point for the agent-scorecard CLI."""
     pass
 
+@cli.command(name="fix")
+@click.argument("path", default=".", type=click.Path(exists=True))
+@click.option("--agent", default="generic", help="Profile to use: generic, jules, copilot.")
+def fix(path: str, agent: str) -> None:
+    """Automatically fixes common issues."""
+    if agent not in PROFILES:
+        console.print(f"[bold red]Unknown agent profile: {agent}. using generic.[/bold red]")
+        agent = "generic"
+
+    profile = PROFILES[agent]
+
+    console.print(Panel(f"[bold cyan]Applying Fixes[/bold cyan]\nProfile: {agent.upper()}", expand=False))
+    apply_fixes(path, profile)
+    console.print("")  # Newline
+    console.print("[bold green]Fixes applied![/bold green]")
+
+
 @cli.command(name="score")
 @click.argument("path", default=".", type=click.Path(exists=True))
 @click.option("--agent", default="generic", help="Profile to use: generic, jules, copilot.")
@@ -137,8 +154,8 @@ def advise(path, output_file):
         stats.append({
             "file": os.path.relpath(filepath, start=path if os.path.isdir(path) else os.path.dirname(path)),
             "loc": analyzer.get_loc(filepath),
-            "complexity": analyzer.get_complexity_score(filepath)[0], # Assuming returns tuple
-            "type_coverage": analyzer.check_type_hints(filepath)[0]   # Assuming returns tuple
+            "complexity": analyzer.get_complexity_score(filepath),
+            "type_coverage": analyzer.check_type_hints(filepath)
         })
 
     final_score = 0 # Placeholder if we don't recalculate

--- a/tests/test_fix_command.py
+++ b/tests/test_fix_command.py
@@ -1,0 +1,67 @@
+import os
+import shutil
+import textwrap
+import pytest
+from click.testing import CliRunner
+from src.agent_scorecard.main import cli
+from src.agent_scorecard.constants import AGENT_CONTEXT_TEMPLATE, INSTRUCTIONS_TEMPLATE
+
+class TestFixCommand:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_fix_command_happy_path(self, runner):
+        with runner.isolated_filesystem():
+            # Create a dummy python file
+            os.makedirs("src")
+            with open("src/test.py", "w") as f:
+                f.write(textwrap.dedent("""
+                    def foo():
+                        pass
+                """))
+
+            # Run fix command with default agent (generic)
+            result = runner.invoke(cli, ["fix", "."])
+
+            assert result.exit_code == 0
+            assert "Applying Fixes" in result.output
+            assert "Fixes applied!" in result.output
+
+            # Check if README.md was created (required by generic)
+            assert os.path.exists("README.md")
+
+            # Check if python file was modified
+            with open("src/test.py", "r") as f:
+                content = f.read()
+            assert "TODO: Add docstring" in content
+            # Note: The exact string depends on constants, but checking for substring is robust enough.
+            assert "TODO: Add type hints" in content
+
+    def test_fix_command_specific_path(self, runner):
+        with runner.isolated_filesystem():
+             # Create a dummy python file in a subdirectory
+            os.makedirs("subdir")
+            with open("subdir/test.py", "w") as f:
+                f.write(textwrap.dedent("""
+                    def bar(x):
+                        return x
+                """))
+
+            # Run fix command on subdir with jules agent (requires agents.md)
+            result = runner.invoke(cli, ["fix", "subdir", "--agent", "jules"])
+
+            assert result.exit_code == 0
+            # Should create docs in subdir because apply_fixes creates docs in the given path if it's a directory
+            assert os.path.exists("subdir/agents.md")
+            assert os.path.exists("subdir/instructions.md")
+
+            with open("subdir/test.py", "r") as f:
+                content = f.read()
+            assert "TODO: Add docstring" in content
+
+    def test_fix_command_invalid_agent(self, runner):
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ["fix", ".", "--agent", "invalid"])
+            assert result.exit_code == 0 # It defaults to generic, so exit code 0
+            assert "Unknown agent profile: invalid. using generic." in result.output


### PR DESCRIPTION
This PR introduces a standalone `fix` command to the CLI, allowing users to automatically apply fixes (creating missing docs, adding TODOs for docstrings and type hints) based on a selected agent profile. It also fixes a bug in the `advise` command which caused it to crash due to incorrect return value handling from `analyzer` functions. Integration tests for the new command have been added.

---
*PR created automatically by Jules for task [9849891303015789420](https://jules.google.com/task/9849891303015789420) started by @brewmarsh*