### PR TITLE
Implement dynamic versioning using setuptools_scm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build setuptools_scm
+
+      - name: Build package
+        run: python -m build
+
+      - name: Verify version matches tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#v}
+          echo "Tag: $TAG"
+          echo "Expected version: $VERSION"
+
+          # Install the built wheel to verify the version
+          pip install dist/*.whl
+          INSTALLED_VERSION=$(python -c "import importlib.metadata; print(importlib.metadata.version('agent-scorecard'))")
+          echo "Installed version: $INSTALLED_VERSION"
+
+          if [ "$INSTALLED_VERSION" != "$VERSION" ]; then
+            echo "ERROR: Version mismatch! Expected $VERSION but got $INSTALLED_VERSION"
+            exit 1
+          fi
+
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 agent_score.svg
+src/agent_scorecard/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools_scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-scorecard"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A tool to analyze codebases for AI-Agent Friendliness"
 readme = "README.md"
 authors = [{ name = "Jules", email = "jules@example.com" }]
@@ -22,3 +22,6 @@ agent-score = "agent_scorecard.main:cli"
 dev = [
     "pytest",
 ]
+
+[tool.setuptools_scm]
+write_to = "src/agent_scorecard/_version.py"

--- a/src/agent_scorecard/main.py
+++ b/src/agent_scorecard/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import click
+from importlib.metadata import version, PackageNotFoundError
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
@@ -98,7 +99,13 @@ def generate_markdown_report(results):
     return md
 
 
+try:
+    __version__ = version("agent-scorecard")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
 @click.group()
+@click.version_option(version=__version__)
 def cli():
     """Main entry point for the agent-scorecard CLI."""
     pass


### PR DESCRIPTION
Implemented dynamic versioning for agent-scorecard using setuptools_scm. 
Key changes:
1. Modified pyproject.toml to remove static versioning and add setuptools_scm configuration.
2. Updated src/agent_scorecard/main.py to include a --version flag that retrieves the version from package metadata.
3. Created a new GitHub Action workflow (.github/workflows/release.yml) to build the package and verify the version on tag push (v*).
4. Updated .gitignore to exclude the auto-generated src/agent_scorecard/_version.py file.

Fixes #23

---
*PR created automatically by Jules for task [8448671666049652291](https://jules.google.com/task/8448671666049652291) started by @brewmarsh*