### PR TITLE
Add Dogfooding Pipeline (GitHub Actions)

### DIFF
--- a/.github/workflows/agent-score.yml
+++ b/.github/workflows/agent-score.yml
@@ -1,0 +1,36 @@
+name: Agent Scorecard Dogfooding
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Run tests
+        run: python -m pytest
+
+      - name: Self-Score
+        run: agent-score src/ --agent=jules --report=scorecard-report.md
+
+      - name: Post Score to Summary
+        if: always()
+        run: |
+          if [ -f scorecard-report.md ]; then
+            cat scorecard-report.md >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow `.github/workflows/agent-score.yml` for dogfooding the `agent-scorecard` tool.

The workflow:
1. Triggers on `push` and `pull_request` to the `main` branch.
2. Sets up Python 3.10.
3. Installs the package with development dependencies.
4. Runs the test suite using `pytest`.
5. Executes `agent-score src/ --agent=jules` to evaluate the codebase's agent-friendliness.
6. Automatically fails the build if the score is below 70 (enforced by the tool's exit code).
7. Generates a Markdown report and appends it to the GitHub Actions Job Summary for easy viewing.

Fixes #11

---
*PR created automatically by Jules for task [7900748670647615942](https://jules.google.com/task/7900748670647615942) started by @brewmarsh*