### PR TITLE
Implement Context Economics (Max Files) in Auditor

### DIFF
--- a/src/agent_scorecard/main.py
+++ b/src/agent_scorecard/main.py
@@ -94,7 +94,11 @@ def score(path: str, agent: str, fix: bool, badge: bool, report_file: str) -> No
     health_table.add_row("Lock File", "[green]PASS[/green]" if health["lock_file"] else "[red]FAIL[/red]")
 
     entropy = auditor.check_directory_entropy(path)
-    entropy_status = f"{entropy['avg_files']:.1f} files/dir"
+    if entropy["warning"] and entropy.get("max_files", 0) > 50:
+        entropy_status = f"Max {entropy['max_files']} files/dir"
+    else:
+        entropy_status = f"{entropy['avg_files']:.1f} files/dir"
+
     entropy_color = "yellow" if entropy["warning"] else "green"
     health_table.add_row("Directory Entropy", f"[{entropy_color}]{entropy_status}[/{entropy_color}]")
 

--- a/tests/test_advisor.py
+++ b/tests/test_advisor.py
@@ -103,11 +103,11 @@ def test_function_stats_parsing(tmp_path):
                 print("yes")
             else:
                 print("no")
-            # padding
-            return 0
     """)
     # Pad to ensure LOC > 20
-    code += "\n" * 20
+    for _ in range(20):
+        code += "    # padding\n"
+    code += "    return 0\n"
 
     p = tmp_path / "test_acl.py"
     p.write_text(code, encoding="utf-8")

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -36,6 +36,26 @@ def test_check_directory_entropy_warning():
         assert result["avg_files"] == 20.0
         assert result["warning"] is True
 
+def test_check_directory_entropy_max_files():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a "God Directory" with 60 files
+        god_dir = os.path.join(tmpdir, "god_dir")
+        os.makedirs(god_dir)
+        for i in range(60):
+            with open(os.path.join(god_dir, f"file{i}.txt"), "w") as f:
+                f.write(".")
+
+        # Create 10 empty folders to dilute the average
+        for i in range(10):
+            os.makedirs(os.path.join(tmpdir, f"empty{i}"))
+
+        result = auditor.check_directory_entropy(tmpdir)
+        # Avg = 60 / 12 = 5.0, but Warning should be True
+        assert result["avg_files"] == 5.0
+        assert result["warning"] is True
+        assert result["max_files"] == 60
+        assert god_dir in result["crowded_dirs"]
+
 def test_get_python_signatures():
     code = """
 def func1(a: int) -> str:


### PR DESCRIPTION
Implement rigorous Context Economics checks in `auditor.py` by flagging any directory with more than 50 files, aligning with Advisor Mode logic. Also fixed a pre-existing test failure in `tests/test_advisor.py`.

---
*PR created automatically by Jules for task [1122914201084519138](https://jules.google.com/task/1122914201084519138) started by @brewmarsh*