### PR TITLE
Implement Prompt Gatekeeper Workflow

### DIFF
--- a/.github/workflows/jules-prompt-gatekeeper.yml
+++ b/.github/workflows/jules-prompt-gatekeeper.yml
@@ -1,0 +1,64 @@
+name: 'Jules: Prompt Gatekeeper'
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  gatekeeper:
+    if: github.event.label.name == 'jules'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install agent-scorecard
+        run: pip install .
+
+      - name: Run Gatekeeper Analysis
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const issueBody = context.payload.issue.body || '';
+            fs.writeFileSync('issue_prompt.txt', issueBody);
+
+            let output = '';
+            const options = {
+              listeners: {
+                stdout: (data) => {
+                  output += data.toString();
+                }
+              },
+              ignoreReturnCode: true
+            };
+
+            const exitCode = await exec.exec('agent-score', ['check-prompts', 'issue_prompt.txt', '--plain'], options);
+
+            if (exitCode !== 0) {
+              // Extract suggestions from output
+              const suggestionsMatch = output.match(/Refactored Suggestions:([\s\S]*?)(\nFAILED:|$)/);
+              const suggestions = suggestionsMatch ? suggestionsMatch[1].trim() : "No specific suggestions found.";
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `🛑 Prompt Physics Check Failed\nI cannot start this task yet because the prompt instructions are ambiguous.\n\nSuggested Improvements:\n${suggestions}`
+              });
+
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'jules'
+              });
+            }

--- a/src/agent_scorecard/main.py
+++ b/src/agent_scorecard/main.py
@@ -158,7 +158,8 @@ def run_scoring(path: str, agent: str, fix: bool, badge: bool, report_path: str,
 
 @cli.command(name="check-prompts")
 @click.argument("path", type=click.Path(exists=True))
-def check_prompts(path: str) -> None:
+@click.option("--plain", is_flag=True, help="Output plain text without colors or tables.")
+def check_prompts(path: str, plain: bool) -> None:
     """Statically analyze text prompts for LLM best practices."""
     analyzer_inst = PromptAnalyzer()
 
@@ -167,6 +168,18 @@ def check_prompts(path: str) -> None:
 
     analysis = analyzer_inst.analyze(content)
     score = analysis["score"]
+
+    if plain:
+        click.echo(f"Prompt Score: {score}/100")
+        if score < 80:
+            click.echo("\nRefactored Suggestions:")
+            for imp in analysis["improvements"]:
+                click.echo(f"- {imp}")
+            click.echo("\nFAILED: Prompt does not meet quality standards.")
+            sys.exit(1)
+        else:
+            click.echo("\nPASSED: Prompt is optimized!")
+        return
 
     table = Table(title=f"Prompt Analysis: {os.path.basename(path)}")
     table.add_column("Heuristic", style="cyan")


### PR DESCRIPTION
This PR implements the "Prompt Gatekeeper" workflow as requested.
It includes:
1. Modifications to `src/agent_scorecard/main.py` to support a `--plain` flag in the `check-prompts` command. This flag ensures the output is easily parseable in CI environments and exits with a non-zero code on failure.
2. A new GitHub Action workflow `.github/workflows/jules-prompt-gatekeeper.yml` that:
   - Triggers when the `jules` label is added to an issue.
   - Installs the `agent-scorecard` tool from source.
   - Extracts the issue body and runs `check-prompts --plain`.
   - If the prompt fails the quality check (score < 80), it posts the suggested improvements as a comment and removes the `jules` label to prevent premature agent execution.

Verified locally with passing and failing prompts. All existing tests pass.

Fixes #62

---
*PR created automatically by Jules for task [9103502373546396911](https://jules.google.com/task/9103502373546396911) started by @brewmarsh*