### PR TITLE
Restore PromptAnalyzer and check-prompts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,18 @@ agent-score score --diff origin/main
 ```
 
 This feature uses `git diff` to identify modified `.py` files and ensures that even if you only check one file, the codebase's global "Agent Physics" (like dependency cycles) remains healthy.
+
+## 📝 Prompt Engineering Linter
+
+Static analysis for your LLM prompts. Ensure your system prompts follow best practices (Role Definition, Few-Shot, CoT) before deploying them to production.
+
+```bash
+agent-score check-prompts prompts/system_v1.txt
+```
+
+### Heuristics Checked:
+* **Role Definition**: Does the prompt establish a persona?
+* **Cognitive Scaffolding**: Are there "Think step-by-step" instructions?
+* **Delimiter Hygiene**: Are instructions separated from data using XML/Markdown tags?
+* **Few-Shot Examples**: Does it include 1-3 examples?
+* **Negative Constraints**: Identifies "Don't" statements and suggests positive alternatives.

--- a/src/agent_scorecard/prompt_analyzer.py
+++ b/src/agent_scorecard/prompt_analyzer.py
@@ -1,0 +1,72 @@
+import re
+from typing import List, Dict, Any
+
+class PromptAnalyzer:
+    """Analyzes text prompts for LLM best practices."""
+
+    HEURISTICS = {
+        "role_definition": {
+            "pattern": r"(?i)(you are|act as|your role)",
+            "improvement": "Add a clear persona (e.g., 'You are a Python Expert') to ground the model's latent space.",
+            "critical": True,
+            "weight": 25
+        },
+        "cognitive_scaffolding": {
+            "pattern": r"(?i)(step by step|reasoning|think)",
+            "improvement": "Add Chain-of-Thought instructions ('Think step by step') to improve complex reasoning.",
+            "critical": False,
+            "weight": 25
+        },
+        "delimiter_hygiene": {
+            "pattern": r"(<[^>]+>|'''|\"\"\"|```|\{\{.*?\}\})",
+            "improvement": "Use delimiters (like XML tags or triple quotes) to separate instructions from input data.",
+            "critical": False,
+            "weight": 25
+        },
+        "few_shot": {
+            "pattern": r"(?i)(example:|input:.*?output:)",
+            "improvement": "Include 1-3 examples (Few-Shot) to guide the model on format and style.",
+            "critical": False,
+            "weight": 25
+        },
+        "negative_constraints": {
+            "pattern": r"(?i)(don't|do not|never)",
+            "improvement": "Refactor negative constraints ('Don't do X') into positive instructions ('Do Y instead') for better adherence.",
+            "critical": False,
+            "penalty": 10
+        }
+    }
+
+    def analyze(self, text: str) -> Dict[str, Any]:
+        """Evaluates a raw string against five key dimensions."""
+        results = {}
+        improvements = []
+        score = 0
+
+        # Positive heuristics
+        for key in ["role_definition", "cognitive_scaffolding", "delimiter_hygiene", "few_shot"]:
+            h = self.HEURISTICS[key]
+            if re.search(h["pattern"], text):
+                results[key] = True
+                score += h["weight"]
+            else:
+                results[key] = False
+                improvements.append(h["improvement"])
+
+        # Negative constraints (Warning)
+        h = self.HEURISTICS["negative_constraints"]
+        if re.search(h["pattern"], text):
+            results["negative_constraints"] = False # Flagged as an issue
+            score -= h["penalty"]
+            improvements.append(h["improvement"])
+        else:
+            results["negative_constraints"] = True
+
+        # Clamp score between 0 and 100
+        score = max(0, min(100, score))
+
+        return {
+            "score": score,
+            "results": results,
+            "improvements": improvements
+        }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,4 +79,26 @@ def test_cli_advise_command():
             content = f.read()
             # RESOLUTION: Use Upgrade logic (Advisor Report header)
             assert "Agent Advisor Report" in content
-        
+
+def test_cli_check_prompts():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Create a perfect prompt file
+        with open("prompt.txt", "w") as f:
+            f.write("""
+You are a helpful assistant.
+Think step by step.
+<input>
+user input
+</input>
+Example:
+Input: A
+Output: B
+            """)
+
+        result = runner.invoke(cli, ["check-prompts", "prompt.txt"])
+        assert result.exit_code == 0
+        assert "Prompt Analysis: prompt.txt" in result.output
+        assert "Role Definition" in result.output
+        assert "Cognitive Scaffolding" in result.output
+        assert "PASSED: Prompt is optimized!" in result.output

--- a/tests/test_prompt_analyzer.py
+++ b/tests/test_prompt_analyzer.py
@@ -1,0 +1,46 @@
+from src.agent_scorecard.prompt_analyzer import PromptAnalyzer
+
+def test_prompt_analyzer_perfect():
+    analyzer = PromptAnalyzer()
+    text = """
+    You are a professional coder.
+    Think step by step to solve the problem.
+    <context>
+    Code here
+    </context>
+    Example:
+    Input: x
+    Output: y
+    """
+    results = analyzer.analyze(text)
+    assert results["score"] == 100
+    assert results["results"]["role_definition"] is True
+    assert results["results"]["cognitive_scaffolding"] is True
+    assert results["results"]["delimiter_hygiene"] is True
+    assert results["results"]["few_shot"] is True
+    assert results["results"]["negative_constraints"] is True # No negative constraints found
+    assert len(results["improvements"]) == 0
+
+def test_prompt_analyzer_low_score():
+    analyzer = PromptAnalyzer()
+    text = "Do the task. Don't fail."
+    results = analyzer.analyze(text)
+    # 0 positive heuristics found, 1 negative constraint penalty
+    # 0 - 10 clamped to 0
+    assert results["score"] == 0
+    assert results["results"]["role_definition"] is False
+    assert results["results"]["negative_constraints"] is False
+    assert len(results["improvements"]) == 5 # 4 missing + 1 penalty
+
+def test_prompt_analyzer_some_heuristics():
+    analyzer = PromptAnalyzer()
+    text = "You are a teacher. Reasoning is important. Never lie."
+    results = analyzer.analyze(text)
+    # Role: 25, CoT (Reasoning): 25, Delimiter: 0, Few-shot: 0. Total: 50.
+    # Penalty: -10. Final score: 40.
+    assert results["score"] == 40
+    assert results["results"]["role_definition"] is True
+    assert results["results"]["cognitive_scaffolding"] is True
+    assert results["results"]["delimiter_hygiene"] is False
+    assert results["results"]["few_shot"] is False
+    assert results["results"]["negative_constraints"] is False


### PR DESCRIPTION
This PR restores the PromptAnalyzer functionality and `check-prompts` CLI command that were seemingly lost during a previous merge (likely PR #61 overwriting PR #60). 

Changes:
- Restored `src/agent_scorecard/prompt_analyzer.py` which implements the prompt analysis heuristics.
- Restored `tests/test_prompt_analyzer.py` for unit testing the analyzer.
- Modified `src/agent_scorecard/main.py` to re-introduce the `check-prompts` command and the necessary import.
- Updated `README.md` to include documentation for the new feature.
- Added a new test case in `tests/test_cli.py` to verify the `check-prompts` command works via the CLI.


---
*PR created automatically by Jules for task [5034890506416336777](https://jules.google.com/task/5034890506416336777) started by @brewmarsh*