### PR TITLE
Fix test_report.py assertions to match CRAFT refactor

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -68,12 +68,12 @@ def test_generate_recommendations_report():
 
     rec_content = generate_recommendations_report(results)
 
-    assert "High Complexity in heavy.py" in rec_content
+    assert "High Complexity: heavy.py" in rec_content
     assert "Missing AGENTS.md" in rec_content
-    assert "Circular Dependency in circular.py" in rec_content
-    assert "Type Coverage < 90% in untyped.py" in rec_content
+    assert "Circular Dependency: circular.py" in rec_content
+    assert "Low Type Safety: untyped.py" in rec_content
 
     assert "Context window overflow." in rec_content
-    assert "Agent guesses build/test commands." in rec_content
-    assert "Infinite recursion loops." in rec_content
-    assert "Hallucination of function signatures." in rec_content
+    assert "Agent guesses repository structure." in rec_content
+    assert "Recursive loops." in rec_content
+    assert "Hallucination of signatures." in rec_content


### PR DESCRIPTION
Updated `tests/test_report.py` to match the expected output of the refactored `generate_recommendations_report` function in `src/agent_scorecard/report.py`. This fixes the test failures caused by the previous refactoring that introduced CRAFT-structured prompts and updated report formatting.

---
*PR created automatically by Jules for task [5791498900119874499](https://jules.google.com/task/5791498900119874499) started by @brewmarsh*