### PR TITLE
fix: enforce stricter ACL thresholds and cleanup imports

### DIFF
--- a/src/agent_scorecard/analyzer.py
+++ b/src/agent_scorecard/analyzer.py
@@ -1,12 +1,10 @@
 import os
 import ast
-import mccabe
-from collections import Counter
-from typing import List, Dict, Any, Tuple, Set, Optional, TypedDict, cast
+from typing import List, Dict, Any, Tuple, Set, Optional, cast
 from .constants import PROFILES
 from .scoring import score_file
 from . import auditor
-from .types import FunctionMetric, FileAnalysisResult, DepAnalysis, DirectoryStat, AnalysisResult
+from .types import FileAnalysisResult, DepAnalysis, DirectoryStat, AnalysisResult
 
 # Re-export metrics for backward compatibility
 from .metrics import (  # noqa: F401

--- a/src/agent_scorecard/config.py
+++ b/src/agent_scorecard/config.py
@@ -30,7 +30,7 @@ DEFAULT_CONFIG: Config = {
     "verbosity": "summary",
     "thresholds": {
         "acl_yellow": 10,  # Warning threshold for cognitive load
-        "acl_red": 20,     # Critical failure threshold
+        "acl_red": 15,     # Critical failure threshold
         "complexity": 10,  # McCabe complexity limit
         "type_safety": 90, # Minimum type hint coverage %
     },

--- a/src/agent_scorecard/main.py
+++ b/src/agent_scorecard/main.py
@@ -4,13 +4,13 @@ import subprocess
 import copy
 import click
 from importlib.metadata import version, PackageNotFoundError
-from typing import List, Dict, Any, Optional, Union, cast, Tuple
+from typing import List, Dict, Any, Optional, Union, cast
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
 
 # Import core modules
-from . import analyzer, report, auditor, metrics
+from . import analyzer, report, auditor
 from .prompt_analyzer import PromptAnalyzer
 from .config import load_config
 from .constants import PROFILES

--- a/src/agent_scorecard/metrics.py
+++ b/src/agent_scorecard/metrics.py
@@ -1,6 +1,6 @@
 import ast
 import mccabe
-from typing import List, Dict, Any
+from typing import List
 from .types import FunctionMetric
 
 

--- a/src/agent_scorecard/prompt_analyzer.py
+++ b/src/agent_scorecard/prompt_analyzer.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Dict, Any, TypedDict, cast
+from typing import List, Dict, TypedDict, cast
 
 
 class HeuristicConfig(TypedDict, total=False):

--- a/src/agent_scorecard/report.py
+++ b/src/agent_scorecard/report.py
@@ -1,6 +1,4 @@
-import os
 from typing import List, Dict, Any, Optional, Union, cast
-from . import analyzer
 from .types import FileAnalysisResult, AnalysisResult, AdvisorFileResult
 
 

--- a/src/agent_scorecard/scoring.py
+++ b/src/agent_scorecard/scoring.py
@@ -17,7 +17,7 @@ def score_file(
     if thresholds is None:
         thresholds = {
             "acl_yellow": p_thresholds.get("acl_yellow", 10),
-            "acl_red": p_thresholds.get("acl_red", 20),
+            "acl_red": p_thresholds.get("acl_red", 15),
             "type_safety": p_thresholds.get("type_safety", 90),
         }
 
@@ -41,7 +41,7 @@ def score_file(
 
     # 3. Extract granular thresholds
     acl_yellow = thresholds.get("acl_yellow", 10)
-    acl_red = thresholds.get("acl_red", 20)
+    acl_red = thresholds.get("acl_red", 15)
     type_safety_threshold = thresholds.get("type_safety", 90)
 
     # 4. ACL Scoring (Agent Cognitive Load)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import pytest
 from agent_scorecard.config import load_config, DEFAULT_CONFIG
 
 def test_load_config_defaults():

--- a/tests/test_regression_guard.py
+++ b/tests/test_regression_guard.py
@@ -1,9 +1,8 @@
 import textwrap
-import os
 from pathlib import Path
 from agent_scorecard.scoring import score_file
 from agent_scorecard.constants import PROFILES
-from agent_scorecard import analyzer, auditor
+from agent_scorecard import analyzer
 
 def test_bloated_files_penalty(tmp_path: Path):
     """Verify that files over 200 lines get a penalty."""


### PR DESCRIPTION
This PR fixes an inconsistency where the default Agent Cognitive Load (ACL) Red threshold was set to 20 instead of the intended 15. This mismatch caused regression guard tests to fail.

Changes:
- Set `acl_red` to 15 in `DEFAULT_CONFIG` in `src/agent_scorecard/config.py`.
- Set `acl_red` to 15 in `score_file` fallback in `src/agent_scorecard/scoring.py`.
- Removed unused imports (mccabe, Counter, etc.) identified by `ruff`.

Testing:
- Ran `uv run pytest` and confirmed all 71 tests pass, including the previously failing `test_acl_strictness`.

---
*PR created automatically by Jules for task [16706857407635555548](https://jules.google.com/task/16706857407635555548) started by @brewmarsh*