### PR TITLE
Add CRAFT Prompts documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,38 @@ agent-score . --fix
 
 ```
 
+## 🤖 Using the CRAFT Prompts
+
+`agent-scorecard` uses the **CRAFT** framework to generate high-quality remediation prompts. If you prefer not to use the `--fix` flag, you can use these prompts manually to guide your favorite AI agent.
+
+### The CRAFT Framework
+
+* **Context**: Defines the persona and background for the task.
+* **Request**: The specific goal or improvement needed.
+* **Actions**: Step-by-step instructions for the agent to follow.
+* **Frame**: The constraints and boundaries (e.g., "don't change logic").
+* **Template**: The expected format of the output.
+
+### Example Prompt: Fixing a God Module
+
+When the scorecard identifies a "God Module" (a file with too many inbound dependencies), it generates a prompt like this:
+
+> **Context**: You are a Software Architect specializing in modular system design.
+> **Request**: Decompose the God Module `main.py` to reduce context pressure.
+> **Actions**:
+> - Identify distinct responsibilities within the module.
+> - Extract logic into smaller, cohesive sub-modules.
+> - Refactor imports to maintain internal dependencies.
+> **Frame**: Inbound imports must stay below 50. Maintain existing functionality.
+> **Template**: A refactoring plan followed by the new module code structure.
+
+### Manual Usage Guide
+
+1. **Run the Scorecard**: Generate your report using `agent-score .`.
+2. **Copy the Prompt**: Locate the "Agent Prompts for Remediation" section in the output.
+3. **Paste into AI**: Copy and paste the CRAFT prompt directly into **Cursor**, **GitHub Copilot**, or **ChatGPT**.
+4. **Apply Fixes**: Use the AI's output to refactor your code with confidence.
+
 ## ⚙️ Configuration
 
 `agent-scorecard` can be configured via `pyproject.toml`, `.agent-scorecard.json`, or CLI flags.


### PR DESCRIPTION
Updated README.md with a new section "## 🤖 Using the CRAFT Prompts" as requested.
- Explained the CRAFT acronym.
- Provided a specific example for fixing a "God Module".
- Added a manual usage guide for copy-pasting prompts into AI tools.

Fixes #88

---
*PR created automatically by Jules for task [12345513965791877736](https://jules.google.com/task/12345513965791877736) started by @brewmarsh*