### PR TITLE
Add professional badges to README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,5 +113,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-agent_score.svg
 src/agent_scorecard/_version.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## 🤖 Agent Scorecard
 
+![Agent Score](./agent_score.svg) [![CI](https://github.com/brewmarsh/agent-readiness-scorecard/actions/workflows/ci.yml/badge.svg)](https://github.com/brewmarsh/agent-readiness-scorecard/actions/workflows/ci.yml) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) ![Python Version](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue) ![Strictly Typed](https://img.shields.io/badge/Strictly-Typed-blue)
+
 **Is your codebase ready for the AI workforce?**
 
 `agent-scorecard` is a CLI tool that analyzes your Python project to determine how "friendly" it is for AI Agents (like Jules, Copilot, Gemini, or Devin).

--- a/agent_score.svg
+++ b/agent_score.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="135" height="20" role="img" aria-label="Agent Score: 89/100">
+    <title>Agent Score: 89/100</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="135" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="85" height="20" fill="#555"/>
+        <rect x="85" width="50" height="20" fill="#97ca00"/>
+        <rect width="135" height="20" fill="url(#s)"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="425.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="750">Agent Readiness</text>
+        <text x="425.0" y="140" transform="scale(.1)" fill="#fff" textLength="750">Agent Readiness</text>
+        <text aria-hidden="true" x="1100.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="400">89/100</text>
+        <text x="1100.0" y="140" transform="scale(.1)" fill="#fff" textLength="400">89/100</text>
+    </g>
+</svg>


### PR DESCRIPTION
Updated the README.md to include a header with several professional badges:
1. Local Agent Readiness badge (`agent_score.svg`).
2. GitHub Actions CI badge for `ci.yml`.
3. Official Ruff badge.
4. Static Python version badge (3.9 | 3.10 | 3.11 | 3.12).
5. "Strictly Typed" badge.

The `agent_score.svg` file was generated and removed from `.gitignore` to ensure it displays correctly in the repository.

Fixes #129

---
*PR created automatically by Jules for task [1178555513459669354](https://jules.google.com/task/1178555513459669354) started by @brewmarsh*