### PR TITLE
Add Average ACL and Type Safety metrics to report summary

### DIFF
--- a/src/agent_scorecard/report.py
+++ b/src/agent_scorecard/report.py
@@ -4,12 +4,21 @@ from .constants import DEFAULT_THRESHOLDS
 from .types import FileAnalysisResult, AnalysisResult, AdvisorFileResult
 
 def _generate_summary_section(
-    final_score: float, profile: Dict[str, Any], project_issues: Optional[List[str]]
+    stats: Union[List[FileAnalysisResult], List[Dict[str, Any]]],
+    final_score: float,
+    profile: Dict[str, Any],
+    project_issues: Optional[List[str]],
 ) -> str:
     """Creates the executive summary section of the report."""
     summary = "# Agent Scorecard Report\n\n"
     summary += f"**Target Agent Profile:** {profile.get('description', 'Generic').split('.')[0]}\n"
     summary += f"**Overall Score: {final_score:.1f}/100** - {'PASS' if final_score >= 70 else 'FAIL'}\n\n"
+
+    if stats:
+        avg_acl = sum(f.get("acl", 0) for f in stats) / len(stats)
+        avg_type_safety = sum(f.get("type_coverage", 0) for f in stats) / len(stats)
+        summary += f"**Average ACL:** {avg_acl:.1f}\n"
+        summary += f"**Average Type Safety:** {avg_type_safety:.0f}%\n\n"
 
     if final_score >= 70:
         summary += "✅ **Status: PASSED** - This codebase is Agent-Ready.\n\n"
@@ -168,7 +177,7 @@ def generate_markdown_report(
     if thresholds is None:
         thresholds = DEFAULT_THRESHOLDS.copy()
 
-    summary = _generate_summary_section(final_score, profile, project_issues)
+    summary = _generate_summary_section(stats, final_score, profile, project_issues)
     targets = _generate_acl_section(stats, thresholds)
     types_section = _generate_type_safety_section(stats, thresholds)
     prompts = _generate_prompts_section(stats, thresholds, project_issues)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -101,3 +101,39 @@ def test_generate_recommendations_report():
     assert "Agent guesses repository structure." in rec_content
     assert "Recursive loops." in rec_content
     assert "Hallucination of signatures." in rec_content
+
+
+def test_generate_report_averages():
+    """Tests that the report summary includes Average ACL and Type Safety metrics."""
+    stats = [
+        {
+            "file": "f1.py",
+            "acl": 10.0,
+            "type_coverage": 50.0,
+            "function_metrics": [],
+            "score": 50,
+            "issues": "",
+        },
+        {
+            "file": "f2.py",
+            "acl": 20.0,
+            "type_coverage": 100.0,
+            "function_metrics": [],
+            "score": 50,
+            "issues": "",
+        },
+    ]
+
+    content = generate_markdown_report(
+        stats=stats,
+        final_score=50.0,
+        path=".",
+        profile=PROFILES["generic"],
+        project_issues=[],
+    )
+
+    # Average ACL: (10 + 20) / 2 = 15.0
+    # Average Type Safety: (50 + 100) / 2 = 75%
+
+    assert "**Average ACL:** 15.0" in content
+    assert "**Average Type Safety:** 75%" in content


### PR DESCRIPTION
This PR adds "Average ACL" and "Average Type Safety" metrics to the executive summary of the generated Markdown report. These metrics provide a high-level overview of the codebase's agent-readiness, allowing users to quickly assess the overall cognitive load and type safety of their project.

Changes:
- `src/agent_scorecard/report.py`: Modified `_generate_summary_section` to calculate averages from `stats` and display them.
- `tests/test_report.py`: Added a new test case `test_generate_report_averages` to verify the output.

---
*PR created automatically by Jules for task [2430391114516393963](https://jules.google.com/task/2430391114516393963) started by @brewmarsh*