### PR TITLE
feat: add Average ACL and Average Type Safety to report summary

### DIFF
--- a/src/agent_scorecard/report.py
+++ b/src/agent_scorecard/report.py
@@ -1,15 +1,25 @@
-import os
 from typing import List, Dict, Any, Optional, Union, cast
 from .constants import DEFAULT_THRESHOLDS
 from .types import FileAnalysisResult, AnalysisResult, AdvisorFileResult
 
 def _generate_summary_section(
-    final_score: float, profile: Dict[str, Any], project_issues: Optional[List[str]]
+    stats: Union[List[FileAnalysisResult], List[Dict[str, Any]]],
+    final_score: float,
+    profile: Dict[str, Any],
+    project_issues: Optional[List[str]],
 ) -> str:
     """Creates the executive summary section of the report."""
     summary = "# Agent Scorecard Report\n\n"
     summary += f"**Target Agent Profile:** {profile.get('description', 'Generic').split('.')[0]}\n"
-    summary += f"**Overall Score: {final_score:.1f}/100** - {'PASS' if final_score >= 70 else 'FAIL'}\n\n"
+    summary += f"**Overall Score: {final_score:.1f}/100** - {'PASS' if final_score >= 70 else 'FAIL'}\n"
+
+    if stats:
+        avg_acl = sum(f.get("acl", 0.0) for f in stats) / len(stats)
+        avg_type_safety = sum(f.get("type_coverage", 0.0) for f in stats) / len(stats)
+        summary += f"**Average ACL:** {avg_acl:.1f}\n"
+        summary += f"**Average Type Safety:** {avg_type_safety:.0f}%\n"
+
+    summary += "\n"
 
     if final_score >= 70:
         summary += "✅ **Status: PASSED** - This codebase is Agent-Ready.\n\n"
@@ -98,7 +108,6 @@ def _generate_prompts_section(
     """Generates structured CRAFT prompts for systemic remediation."""
     acl_yellow = thresholds.get("acl_yellow", DEFAULT_THRESHOLDS["acl_yellow"])
     acl_red = thresholds.get("acl_red", DEFAULT_THRESHOLDS["acl_red"])
-    type_safety_threshold = thresholds.get("type_safety", DEFAULT_THRESHOLDS["type_safety"])
 
     prompts = "## 🤖 Agent Prompts for Remediation (CRAFT Format)\n\n"
 
@@ -168,7 +177,7 @@ def generate_markdown_report(
     if thresholds is None:
         thresholds = DEFAULT_THRESHOLDS.copy()
 
-    summary = _generate_summary_section(final_score, profile, project_issues)
+    summary = _generate_summary_section(stats, final_score, profile, project_issues)
     targets = _generate_acl_section(stats, thresholds)
     types_section = _generate_type_safety_section(stats, thresholds)
     prompts = _generate_prompts_section(stats, thresholds, project_issues)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import pytest
 from agent_scorecard.config import load_config, DEFAULT_CONFIG
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -15,6 +15,7 @@ def test_generate_markdown_report():
             "loc": 250,
             "complexity": 15,
             "type_coverage": 0,
+            "acl": 25.0,
             "function_metrics": [
                 {
                     "name": "complex_untyped",
@@ -32,6 +33,7 @@ def test_generate_markdown_report():
             "loc": 50,
             "complexity": 2,
             "type_coverage": 100,
+            "acl": 3.0,
             "function_metrics": [
                 {
                     "name": "simple_typed",
@@ -56,6 +58,10 @@ def test_generate_markdown_report():
     assert "# Agent Scorecard Report" in report_content
     assert "Overall Score: 70.0/100" in report_content
     assert "PASSED" in report_content
+
+    # Verify New Summary Metrics (Average ACL & Type Safety)
+    assert "**Average ACL:** 14.0" in report_content
+    assert "**Average Type Safety:** 50%" in report_content
 
     # Verify Upgrade Branch Features (ACL & Type Safety)
     assert "Top Refactoring Targets (Agent Cognitive Load (ACL))" in report_content


### PR DESCRIPTION
This PR adds 'Average ACL' and 'Average Type Safety' metrics to the executive summary of the Agent Scorecard report. This provides a quick overview of the codebase's average complexity and type coverage. It also includes updates to the tests to verify these new metrics and some minor code cleanup.

---
*PR created automatically by Jules for task [6423247601670604286](https://jules.google.com/task/6423247601670604286) started by @brewmarsh*