### PR TITLE
Use GH_PAT for prompt gatekeeper to enable downstream triggers

### DIFF
--- a/.github/workflows/jules-prompt-gatekeeper.yml
+++ b/.github/workflows/jules-prompt-gatekeeper.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Run Gatekeeper Analysis
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             const fs = require('fs');
             const issueOrPR = context.payload.issue || context.payload.pull_request;


### PR DESCRIPTION
The 'Jules: Prompt Gatekeeper' workflow was using the default `GITHUB_TOKEN` to add the 'jules' label to issues and pull requests. GitHub prevents events triggered by `GITHUB_TOKEN` from initiating subsequent workflows to avoid infinite loops.

This PR updates the `actions/github-script@v7` step in `.github/workflows/jules-prompt-gatekeeper.yml` to use a custom repository secret `GH_PAT`. 

**Action Required:**
The user must generate a Classic Personal Access Token (PAT) with `repo` scope and store it as a repository secret named `GH_PAT` in the repository settings.

Fixes #153

---
*PR created automatically by Jules for task [15042995881997909776](https://jules.google.com/task/15042995881997909776) started by @brewmarsh*