### PR TITLE
Fix unused imports and export symbols in report.py

### DIFF
--- a/scripts/process_scorecard.py
+++ b/scripts/process_scorecard.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 import json
 import os
-from typing import List, Dict, Any
+from typing import List, Dict
 
 
 def check_issue_exists(file_path: str, issue_type: str) -> bool:

--- a/src/agent_scorecard/report.py
+++ b/src/agent_scorecard/report.py
@@ -1,7 +1,14 @@
 from typing import List, Dict, Any, Optional, Union, cast
 from .constants import DEFAULT_THRESHOLDS
-from .types import FileAnalysisResult, AnalysisResult, AdvisorFileResult
+from .types import FileAnalysisResult, AdvisorFileResult
 from .remediation import generate_prompts_section, generate_recommendations_report
+
+__all__ = [
+    "generate_markdown_report",
+    "generate_advisor_report",
+    "generate_prompts_section",
+    "generate_recommendations_report",
+]
 
 
 def _generate_summary_section(


### PR DESCRIPTION
- Removed unused `typing.Any` import from `scripts/process_scorecard.py`.
- Removed unused `AnalysisResult` import from `src/agent_scorecard/report.py`.
- Added `__all__` to `src/agent_scorecard/report.py` to explicitly export `generate_markdown_report`, `generate_advisor_report`, `generate_prompts_section`, and `generate_recommendations_report`, resolving linting warnings while preserving backward compatibility for re-exports.

---
*PR created automatically by Jules for task [12972253546666690612](https://jules.google.com/task/12972253546666690612) started by @brewmarsh*