### PR TITLE
chore: Improve type safety in tests and scripts

### DIFF
--- a/scripts/process_scorecard.py
+++ b/scripts/process_scorecard.py
@@ -3,9 +3,10 @@ import re
 import subprocess
 import json
 import os
+from typing import List, Dict
 
 
-def check_issue_exists(file_path, issue_type):
+def check_issue_exists(file_path: str, issue_type: str) -> bool:
     """
     Checks if an open GitHub issue with the same title already exists.
     Title format: Refactor: <file_path> (<issue_type>)
@@ -37,7 +38,7 @@ def check_issue_exists(file_path, issue_type):
         return False
 
 
-def create_issue(file_path, issue_type, craft_prompt):
+def create_issue(file_path: str, issue_type: str, craft_prompt: str) -> None:
     """
     Creates a new GitHub issue using the gh CLI.
     The CRAFT prompt is used as the issue body.
@@ -65,7 +66,7 @@ def create_issue(file_path, issue_type, craft_prompt):
         print(f"Error creating issue: {e}")
 
 
-def main():
+def main() -> None:
     if len(sys.argv) < 2:
         print("Usage: python scripts/process_scorecard.py <scorecard_file>")
         sys.exit(1)
@@ -86,7 +87,7 @@ def main():
     pattern = r"### File: `(.+?)` - (High Cognitive Load|Low Type Safety)\n(.*?)(?=\n### File:|\n### 📂 Full File Analysis|\Z)"
     matches = re.finditer(pattern, content, re.DOTALL)
 
-    typing_tasks = []
+    typing_tasks: List[Dict[str, str]] = []
 
     for match in matches:
         file_path = match.group(1)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+
 import pytest
 from src.agent_scorecard.dependencies import (
     get_import_graph,
@@ -7,7 +9,9 @@ from src.agent_scorecard.dependencies import (
     _collect_python_files,
 )
 
-def test_collect_python_files(tmp_path):
+
+def test_collect_python_files(tmp_path: Path) -> None:
+    """Verifies that python files are correctly collected from a directory."""
     d = tmp_path / "subdir"
     d.mkdir()
     (d / "file1.py").write_text("print('hello')")
@@ -19,7 +23,9 @@ def test_collect_python_files(tmp_path):
     assert any(f.endswith("file1.py") for f in files)
     assert any(f.endswith("root.py") for f in files)
 
-def test_import_graph_and_cycles(tmp_path):
+
+def test_import_graph_and_cycles(tmp_path: Path) -> None:
+    """Verifies import graph construction and cycle detection."""
     # A -> B -> C -> A (cycle)
     # D -> B
 
@@ -42,7 +48,9 @@ def test_import_graph_and_cycles(tmp_path):
     # Canonical cycle should start with min element
     assert cycle == ["a.py", "b.py", "c.py"]
 
-def test_calculate_context_tokens(tmp_path):
+
+def test_calculate_context_tokens(tmp_path: Path) -> None:
+    """Verifies context token calculation for simple dependencies."""
     # A -> B
     # B has 10 tokens
     # A has 20 tokens
@@ -64,7 +72,9 @@ def test_calculate_context_tokens(tmp_path):
     assert context["b.py"] == 10
     assert context["a.py"] == 30
 
-def test_calculate_context_tokens_with_cycle(tmp_path):
+
+def test_calculate_context_tokens_with_cycle(tmp_path: Path) -> None:
+    """Verifies context token calculation with cycles."""
     # A -> B -> A
     # A: 10, B: 20
     # Context(A) = 10 + 20 = 30
@@ -85,7 +95,9 @@ def test_calculate_context_tokens_with_cycle(tmp_path):
     assert context["a.py"] == 30
     assert context["b.py"] == 30
 
-def test_calculate_context_tokens_complex(tmp_path):
+
+def test_calculate_context_tokens_complex(tmp_path: Path) -> None:
+    """Verifies context token calculation for complex graphs."""
     # A -> B, C
     # B -> D
     # C -> D

--- a/tests/test_token_economics.py
+++ b/tests/test_token_economics.py
@@ -3,7 +3,7 @@ import tempfile
 from agent_scorecard.analyzer import perform_analysis
 
 
-def test_cumulative_token_budget_exceeded():
+def test_cumulative_token_budget_exceeded() -> None:
     """
     Tests that a small file importing a massive module triggers a token budget alert.
     """
@@ -42,7 +42,7 @@ def test_cumulative_token_budget_exceeded():
         assert main_result["score"] < 100
 
 
-def test_cumulative_token_budget_within_limit():
+def test_cumulative_token_budget_within_limit() -> None:
     """
     Tests that a small file with small imports does not trigger the alert.
     """


### PR DESCRIPTION
Added type hints and docstrings to `tests/test_token_economics.py`, `tests/test_dependencies.py`, and `scripts/process_scorecard.py`. This improves the Agent Scorecard score by removing the "Type Safety Index" penalty from these files.

---
*PR created automatically by Jules for task [12780317784828345525](https://jules.google.com/task/12780317784828345525) started by @brewmarsh*