### PR TITLE
Multilang 4: UX & Configuration (Multi-Language Reporting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ report_style = "actionable"
 acl_yellow = 10
 acl_red = 15
 type_safety = 90
+
+# Language-specific overrides
+[tool.agent-scorecard.javascript.thresholds]
+acl_yellow = 12
+acl_red = 18
+
+[tool.agent-scorecard.markdown.thresholds]
+token_limit = 64000
 ```
 
 ### Verbosity Levels (CLI Output)

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -28,3 +28,20 @@ Agents traverse code like a graph.
 Context is currency.
 * **Token Budget:** >32k tokens in a critical path risks "forgetting" instructions.
 * **Directory Entropy:** Too many files in one folder confuses retrieval tools.
+
+## 4. Multi-Language Support
+`agent-scorecard` uses the Strategy Pattern to apply language-specific "Physics" to different file types.
+
+### Language-Specific Configuration
+You can customize thresholds for each language in `pyproject.toml`. This allows for different complexity tolerances across your stack.
+
+```toml
+[tool.agent-scorecard.python.thresholds]
+acl_yellow = 10
+
+[tool.agent-scorecard.javascript.thresholds]
+acl_yellow = 12
+acl_red = 18
+```
+
+The tool will automatically detect the language (Python, JavaScript, Markdown, Docker) and apply the appropriate overrides, falling back to global thresholds if none are specified.

--- a/src/agent_scorecard/analyzer.py
+++ b/src/agent_scorecard/analyzer.py
@@ -139,6 +139,7 @@ def perform_analysis(
     profile: Optional[Dict[str, Any]] = None,
     thresholds: Optional[Dict[str, Any]] = None,
     report_style: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
 ) -> AnalysisResult:
     """
     Orchestrates the full project analysis pipeline with Context Economics and Custom Reporting.
@@ -174,14 +175,27 @@ def perform_analysis(
         cum_tokens = cumulative_tokens_map.get(rel_path, 0)
 
         analyzer = get_analyzer(filepath)
+        lang = analyzer.language
+
+        # Merge global thresholds with language-specific overrides if available
+        active_thresholds = (thresholds or {}).copy()
+        if config:
+            lang_cfg = config.get(lang.lower(), {})
+            lang_thresholds = lang_cfg.get("thresholds", {})
+            active_thresholds.update(lang_thresholds)
+
         score, issues, loc, complexity, type_safety, metrics_data = analyzer.score_file(
-            filepath, profile, thresholds=thresholds, cumulative_tokens=cum_tokens
+            filepath,
+            profile,
+            thresholds=active_thresholds,
+            cumulative_tokens=cum_tokens,
         )
         file_scores.append(score)
 
         file_results.append(
             {
                 "file": rel_path,
+                "language": lang,
                 "score": score,
                 "issues": issues,
                 "loc": loc,

--- a/src/agent_scorecard/analyzers/base.py
+++ b/src/agent_scorecard/analyzers/base.py
@@ -8,6 +8,14 @@ class BaseAnalyzer(ABC):
     Abstract base class for language-specific analyzers.
     """
 
+    @property
+    @abstractmethod
+    def language(self) -> str:
+        """
+        Returns the name of the language this analyzer handles.
+        """
+        pass
+
     @abstractmethod
     def score_file(
         self,

--- a/src/agent_scorecard/analyzers/docker.py
+++ b/src/agent_scorecard/analyzers/docker.py
@@ -10,6 +10,10 @@ class DockerAnalyzer(BaseAnalyzer):
     Evaluates Agent Cognitive Load (ACL) based on instruction complexity.
     """
 
+    @property
+    def language(self) -> str:
+        return "Docker"
+
     def score_file(
         self,
         filepath: str,

--- a/src/agent_scorecard/analyzers/markdown.py
+++ b/src/agent_scorecard/analyzers/markdown.py
@@ -11,6 +11,10 @@ class MarkdownAnalyzer(BaseAnalyzer):
     Evaluates Agent Cognitive Load (ACL) based on header depth and token density.
     """
 
+    @property
+    def language(self) -> str:
+        return "Markdown"
+
     def score_file(
         self,
         filepath: str,

--- a/src/agent_scorecard/analyzers/python.py
+++ b/src/agent_scorecard/analyzers/python.py
@@ -64,6 +64,10 @@ class PythonAnalyzer(BaseAnalyzer):
     Python-specific implementation of the BaseAnalyzer.
     """
 
+    @property
+    def language(self) -> str:
+        return "Python"
+
     def score_file(
         self,
         filepath: str,

--- a/src/agent_scorecard/config.py
+++ b/src/agent_scorecard/config.py
@@ -24,13 +24,18 @@ class Thresholds(TypedDict, total=False):
     acl_red: int
     complexity: int
     type_safety: int
+    token_limit: int
 
 
-class Config(TypedDict):
+class Config(TypedDict, total=False):
     verbosity: str
     report_style: str
     thresholds: Thresholds
     llm: Dict[str, Any]
+    python: Dict[str, Any]
+    javascript: Dict[str, Any]
+    markdown: Dict[str, Any]
+    docker: Dict[str, Any]
 
 
 # Unified defaults representing core Agent Physics

--- a/src/agent_scorecard/main.py
+++ b/src/agent_scorecard/main.py
@@ -421,6 +421,7 @@ def score(
         limit_to_files=limit_to_files,
         thresholds=thresholds,
         report_style=final_report_style,
+        config=cfg,
     )
 
     _print_environment_health(path, results, final_verbosity)
@@ -478,7 +479,10 @@ def advise(path: str, output_file: Optional[str]) -> None:
     console.print(Panel("[bold cyan]Running Advisor Mode[/bold cyan]", expand=False))
     cfg = load_config(path)
     results = analyzer.perform_analysis(
-        path, "generic", thresholds=cast(Dict[str, Any], cfg.get("thresholds"))
+        path,
+        "generic",
+        thresholds=cast(Dict[str, Any], cfg.get("thresholds")),
+        config=cfg,
     )
 
     stats: List[AdvisorFileResult] = []

--- a/src/agent_scorecard/report.py
+++ b/src/agent_scorecard/report.py
@@ -113,28 +113,59 @@ def _generate_file_table_section(
     verbosity: str = "detailed",
 ) -> str:
     """
-    Creates a breakdown of analysis for every file.
+    Creates a breakdown of analysis for every file grouped by language.
     """
     if verbosity == "summary":
-        table = "### 📂 Failing File Analysis\n\n"
+        title = "### 📂 Failing File Analysis"
     else:
-        table = "### 📂 Full File Analysis\n\n"
+        title = "### 📂 Full File Analysis"
 
-    table += "| File | Score | Issues |\n"
-    table += "| :--- | :---: | :--- |\n"
-    has_rows = False
+    # Group files by language
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
     for res in stats:
-        score = res.get("score", 0)
-        if verbosity == "summary" and score >= 70:
-            continue
-        status = "✅" if score >= 70 else "❌"
-        table += f"| {res['file']} | {score} {status} | {res.get('issues', '')} |\n"
-        has_rows = True
+        lang = res.get("language", "Unknown")
+        if lang not in grouped:
+            grouped[lang] = []
+        grouped[lang].append(res)
 
-    if not has_rows and verbosity == "summary":
+    sections = []
+    for lang in sorted(grouped.keys()):
+        lang_files = grouped[lang]
+        failing = [f for f in lang_files if f.get("score", 0) < 70]
+        passing = [f for f in lang_files if f.get("score", 0) >= 70]
+
+        if not failing and verbosity == "summary":
+            continue
+
+        lang_section = [f"#### {lang}"]
+
+        if failing:
+            lang_section.append("| File | Score | Issues |")
+            lang_section.append("| :--- | :---: | :--- |")
+            for res in failing:
+                lang_section.append(
+                    f"| {res['file']} | {res['score']} ❌ | {res.get('issues', '')} |"
+                )
+
+        if passing and verbosity == "detailed":
+            lang_section.append("\n<details>")
+            lang_section.append(
+                f"<summary>View {len(passing)} Passing {lang} Files</summary>\n"
+            )
+            lang_section.append("| File | Score | Issues |")
+            lang_section.append("| :--- | :---: | :--- |")
+            for res in passing:
+                lang_section.append(f"| {res['file']} | {res['score']} ✅ | |")
+            lang_section.append("\n</details>\n")
+        elif passing and failing and verbosity == "summary":
+            lang_section.append(f"\n*Plus {len(passing)} passing files hidden.*\n")
+
+        sections.append("\n".join(lang_section))
+
+    if not sections and verbosity == "summary":
         return "### 📂 File Analysis\n\n✅ All files passed!\n"
 
-    return table
+    return title + "\n\n" + "\n\n".join(sections)
 
 
 def generate_markdown_report(

--- a/src/agent_scorecard/types.py
+++ b/src/agent_scorecard/types.py
@@ -17,6 +17,7 @@ class FileAnalysisResult(TypedDict):
     """The result of analyzing a single source file."""
 
     file: str
+    language: str
     score: int
     issues: str
     loc: int


### PR DESCRIPTION
This change enhances the multi-language support by allowing users to define language-specific thresholds in their configuration and improving the reporting UX by grouping files by language.

Key changes:
1.  **Types & Config**: Updated `src/agent_scorecard/types.py` and `src/agent_scorecard/config.py` to support language-specific configuration sections and a new `language` field in results.
2.  **Analyzers**: Added a `language` property to all analyzers (Python, Markdown, Docker) via the `BaseAnalyzer` interface.
3.  **Analysis Orchestration**: Updated `perform_analysis` to correctly merge and apply language-specific thresholds.
4.  **Reporting**: Re-designed the "File Analysis" section of the Markdown report to group results by language and use `<details>` blocks for passing files, reducing visual noise.
5.  **Documentation**: Updated `README.md` and `docs/CONCEPTS.md` with usage examples for the new configuration features.

Fixes #215

---
*PR created automatically by Jules for task [13665621947298412642](https://jules.google.com/task/13665621947298412642) started by @brewmarsh*