### PR TITLE
fix: implement missing language property in JavascriptAnalyzer

### DIFF
--- a/src/agent_scorecard/analyzers/javascript.py
+++ b/src/agent_scorecard/analyzers/javascript.py
@@ -19,6 +19,10 @@ class JavascriptAnalyzer(BaseAnalyzer):
     Calculates ACL: (Depth * 2) + (Complexity * 1.5) + (LOC / 50).
     """
 
+    @property
+    def language(self) -> str:
+        return "JavaScript/TypeScript"
+
     def _get_language(self, filepath: str) -> Language:
         if filepath.endswith(".tsx"):
             return TSX_LANGUAGE


### PR DESCRIPTION
Implemented the `language` property in `JavascriptAnalyzer` to return "JavaScript/TypeScript". This resolves a `TypeError` encountered during instantiation because `JavascriptAnalyzer` did not implement the abstract `language` property defined in `BaseAnalyzer`.Verified the fix with `tests/test_javascript_analyzer.py` and the full test suite.

---
*PR created automatically by Jules for task [6761263048998088105](https://jules.google.com/task/6761263048998088105) started by @brewmarsh*