### PR TITLE
ci: enforce beta branch requirement across all workflows

### DIFF
--- a/.github/workflows/agent-advisor.yaml
+++ b/.github/workflows/agent-advisor.yaml
@@ -7,7 +7,25 @@ on:
     - cron: '0 9 * * 1' # Runs every Monday at 9am (Weekly Audit)
 
 jobs:
+  check-branch:
+    name: 🚩 Branch Enforcement
+    runs-on: ubuntu-latest
+    if: github.base_ref == 'main'
+    steps:
+      - name: Verify Base Branch
+        run: |
+          if [ "${{ github.head_ref }}" != "beta" ]; then
+            echo "🛑 ERROR: All Pull Requests to 'main' must originate from the 'beta' branch."
+            echo "Current head branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "✅ Branch check passed: PR from 'beta' to 'main'."
+
   analyze:
+    needs: [check-branch]
+    if: |
+      always() &&
+      (needs.check-branch.result == 'success' || needs.check-branch.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # Needed to comment on PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,26 @@ on:
       - main
 
 jobs:
+  check-branch:
+    name: 🚩 Branch Enforcement
+    runs-on: ubuntu-latest
+    if: github.base_ref == 'main'
+    steps:
+      - name: Verify Base Branch
+        run: |
+          if [ "${{ github.head_ref }}" != "beta" ]; then
+            echo "🛑 ERROR: All Pull Requests to 'main' must originate from the 'beta' branch."
+            echo "Current head branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "✅ Branch check passed: PR from 'beta' to 'main'."
+
   test:
     name: Test on Python ${{ matrix.python-version }}
+    needs: [check-branch]
+    if: |
+      always() &&
+      (needs.check-branch.result == 'success' || needs.check-branch.result == 'skipped')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/scorecard_automation.yml
+++ b/.github/workflows/scorecard_automation.yml
@@ -12,7 +12,25 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight
 
 jobs:
+  check-branch:
+    name: 🚩 Branch Enforcement
+    runs-on: ubuntu-latest
+    if: github.base_ref == 'main'
+    steps:
+      - name: Verify Base Branch
+        run: |
+          if [ "${{ github.head_ref }}" != "beta" ]; then
+            echo "🛑 ERROR: All Pull Requests to 'main' must originate from the 'beta' branch."
+            echo "Current head branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "✅ Branch check passed: PR from 'beta' to 'main'."
+
   remediate:
+    needs: [check-branch]
+    if: |
+      always() &&
+      (needs.check-branch.result == 'success' || needs.check-branch.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Extended the beta branch enforcement policy to `ci.yml`, `scorecard_automation.yml`, and `agent-advisor.yaml`. This ensures that all Pull Requests targeting `main` must originate from the `beta` branch, preventing invalid PRs from consuming CI resources and maintaining the release workflow integrity.

---
*PR created automatically by Jules for task [968447607900553615](https://jules.google.com/task/968447607900553615) started by @brewmarsh*