### PR TITLE
test(js): Add PEP 484 type hint to js_analyzer fixture

### DIFF
--- a/tests/test_javascript_analyzer.py
+++ b/tests/test_javascript_analyzer.py
@@ -5,7 +5,7 @@ from agent_scorecard.analyzers.javascript import JavascriptAnalyzer
 
 
 @pytest.fixture
-def js_analyzer():
+def js_analyzer() -> JavascriptAnalyzer:
     return JavascriptAnalyzer()
 
 


### PR DESCRIPTION
Fixes missing type hint on the `js_analyzer` fixture in `tests/test_javascript_analyzer.py`, resolving mypy warnings and aligning with the project's strict type safety standards.

---
*PR created automatically by Jules for task [4268441963506237035](https://jules.google.com/task/4268441963506237035) started by @brewmarsh*