### PR TITLE
Implement Advanced Filtering and Sorting for CLI

### DIFF
--- a/src/agent_scorecard/main.py
+++ b/src/agent_scorecard/main.py
@@ -17,7 +17,7 @@ from .config import load_config
 from .constants import PROFILES
 from .fix import apply_fixes
 from .scoring import generate_badge
-from .types import AnalysisResult, AdvisorFileResult
+from .types import AnalysisResult, AdvisorFileResult, FileAnalysisResult
 
 console = Console()
 
@@ -339,6 +339,22 @@ def fix(path: str, agent: str) -> None:
     default="origin/main",
     help="Base reference for diff (default: origin/main).",
 )
+@click.option(
+    "--sort",
+    type=click.Choice(["score", "acl", "tokens", "types"]),
+    default="score",
+    help="Sort results by metric.",
+)
+@click.option(
+    "--top",
+    type=int,
+    help="Limit output to the N worst-offending files.",
+)
+@click.option(
+    "--failing",
+    is_flag=True,
+    help="Filter results to show only failing files (score < 70).",
+)
 def score(
     path: str,
     agent: str,
@@ -350,6 +366,9 @@ def score(
     limit_to: tuple,
     diff: bool,
     diff_base: str,
+    sort: str,
+    top: Optional[int],
+    failing: bool,
 ) -> None:
     """
     Scores a codebase based on agent compatibility.
@@ -427,6 +446,30 @@ def score(
         report_style=final_report_style,
         config=cast(Dict[str, Any], cfg),
     )
+
+    # --- Filtering, Sorting, and Limiting ---
+    file_results = cast(List[Dict[str, Any]], results["file_results"])
+
+    # 1. Filtering
+    if failing:
+        file_results = [res for res in file_results if res["score"] < 70]
+
+    # 2. Sorting
+    reverse_map = {"score": False, "acl": True, "tokens": True, "types": False}
+    key_map = {
+        "score": lambda x: x["score"],
+        "acl": lambda x: x["acl"],
+        "tokens": lambda x: x.get("cumulative_tokens", 0),
+        "types": lambda x: x["type_coverage"],
+    }
+
+    file_results.sort(key=key_map[sort], reverse=reverse_map[sort])
+
+    # 3. Limiting
+    if top is not None:
+        file_results = file_results[:top]
+
+    results["file_results"] = cast(List[FileAnalysisResult], file_results)
 
     _print_environment_health(path, results, final_verbosity)
     _print_file_analysis(results, final_verbosity)


### PR DESCRIPTION
Implemented advanced sorting, filtering, and limiting options for the `agent-scorecard` CLI output table.

New CLI options for the `score` command:
- `--sort [score|acl|tokens|types]`: Sort results by the specified metric.
  - `score` (default): Ascending (worst score first).
  - `acl`: Descending (highest cognitive load first).
  - `tokens`: Descending (largest cumulative context first).
  - `types`: Ascending (lowest type coverage first).
- `--top N`: Limit the output table to the N worst-offending files after sorting.
- `--failing`: A boolean flag to only show files with an Agent Readiness Score below 70.

The implementation preserves global project metrics and the final score while allowing users to focus on specific problematic areas of large projects. It follows the "Unix Philosophy" by providing powerful tools behind simple flags.

Verified with the full test suite and manual CLI execution.

---
*PR created automatically by Jules for task [11340520373892160590](https://jules.google.com/task/11340520373892160590) started by @brewmarsh*