### PR TITLE
Rework branch enforcement and quality gates

### DIFF
--- a/.github/workflows/agent-gatekeeper.yaml
+++ b/.github/workflows/agent-gatekeeper.yaml
@@ -3,30 +3,15 @@ name: 🛡️ Agent Quality Gate
 on:
   pull_request:
     branches: [ main, beta ]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
 
 jobs:
-  check-branch:
-    name: 🚩 Branch Enforcement
+  enforcement:
+    name: 🚩 Branch & Quality Enforcement
     runs-on: ubuntu-latest
-    if: github.base_ref == 'main'
-    steps:
-      - name: Verify Base Branch
-        run: |
-          if [ "${{ github.head_ref }}" != "beta" ]; then
-            echo "🛑 ERROR: All Pull Requests to 'main' must originate from the 'beta' branch."
-            echo "Current head branch: ${{ github.head_ref }}"
-            exit 1
-          fi
-          echo "✅ Branch check passed: PR from 'beta' to 'main'."
-
-  agent-review:
-    name: 🤖 Agent Quality Review
-    runs-on: ubuntu-latest
-    # Run if branch check passed (or was skipped for beta PRs)
-    needs: [check-branch]
-    if: |
-      always() && 
-      (needs.check-branch.result == 'success' || needs.check-branch.result == 'skipped')
+    permissions:
+      pull-requests: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -47,9 +32,79 @@ jobs:
         run: |
           uv pip install --system -e "."
 
-      - name: Run Agent Scorecard
+      - name: "Context Discovery & Quality Tiering"
+        id: gatekeeper
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          agent-score . --verbosity summary --report pr_health.md
+          # Use event-specific base ref if github.base_ref is empty (common in pull_request_review)
+          TARGET="${{ github.base_ref || github.event.pull_request.base.ref }}"
+          SOURCE="${{ github.head_ref || github.event.pull_request.head.ref }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          echo "::group::Context Discovery"
+          echo "Target Branch: $TARGET"
+          echo "Source Branch: $SOURCE"
+          echo "PR Number: $PR_NUMBER"
+          echo "::endgroup::"
+
+          if [[ "$TARGET" == "main" ]]; then
+            echo "::group::Main Branch Enforcement (Strict)"
+
+            # 1. Branch Source Check
+            if [[ "$SOURCE" != "beta" ]]; then
+              echo "### 🛑 Enforcement Failure" >> $GITHUB_STEP_SUMMARY
+              echo "Targeting 'main' requires source=beta, but found source=$SOURCE" >> $GITHUB_STEP_SUMMARY
+              echo "🛑 ERROR: All Pull Requests to 'main' must originate from the 'beta' branch."
+              exit 1
+            fi
+
+            # 2. Mandatory Review Check
+            echo "Checking for PR approval..."
+            APPROVALS=$(gh pr view $PR_NUMBER --json reviews --jq '.reviews | map(select(.state == "APPROVED")) | length')
+            if [[ "$APPROVALS" -eq 0 ]]; then
+              echo "### 🛑 Enforcement Failure" >> $GITHUB_STEP_SUMMARY
+              echo "Targeting 'main' requires at least one approved review." >> $GITHUB_STEP_SUMMARY
+              echo "🛑 ERROR: PR must be approved before merging to 'main'."
+              exit 1
+            fi
+
+            # 3. Scorecard Check
+            echo "Running Scorecard with High Threshold (>= 90)..."
+            agent-score . --verbosity summary --report pr_health.md --fail-under 90 || {
+              echo "### 🛑 Scorecard Failure" >> $GITHUB_STEP_SUMMARY
+              echo "Targeting 'main' requires an Agent Scorecard pass >= 90." >> $GITHUB_STEP_SUMMARY
+              exit 1
+            }
+            echo "::endgroup::"
+
+          elif [[ "$TARGET" == "beta" ]]; then
+            echo "::group::Beta Branch Enforcement (Standard)"
+
+            # 1. Parsing Fix Verification
+            echo "Verifying node_modules pruning fix..."
+            if ! grep -q "node_modules" src/agent_scorecard/dependencies.py; then
+              echo "### 🛑 Enforcement Failure" >> $GITHUB_STEP_SUMMARY
+              echo "Targeting 'beta' requires 'node_modules' pruning logic fixes." >> $GITHUB_STEP_SUMMARY
+              echo "🛑 ERROR: node_modules parsing fixes are missing in src/agent_scorecard/dependencies.py"
+              exit 1
+            fi
+
+            # 2. Scorecard Check
+            echo "Running Scorecard with Standard Threshold (>= 70)..."
+            agent-score . --verbosity summary --report pr_health.md --fail-under 70 || {
+              echo "### 🛑 Scorecard Failure" >> $GITHUB_STEP_SUMMARY
+              echo "Targeting 'beta' requires an Agent Scorecard pass >= 70." >> $GITHUB_STEP_SUMMARY
+              exit 1
+            }
+            echo "::endgroup::"
+
+          else
+            echo "::group::Default Branch Enforcement"
+            echo "Applying default enforcement for branch: $TARGET"
+            agent-score . --verbosity summary --report pr_health.md --fail-under 70
+            echo "::endgroup::"
+          fi
 
       - name: Post Summary to GITHUB_STEP_SUMMARY
         if: always()
@@ -57,5 +112,9 @@ jobs:
           if [ -f pr_health.md ]; then
             cat pr_health.md >> $GITHUB_STEP_SUMMARY
           else
-            echo "No scorecard report generated." >> $GITHUB_STEP_SUMMARY
+            # Only add this if not already added by previous steps
+            if ! grep -q "### 🛑" $GITHUB_STEP_SUMMARY 2>/dev/null; then
+              echo "### ⚠️ Scorecard Result" >> $GITHUB_STEP_SUMMARY
+              echo "No scorecard report generated. Check the logs for enforcement details." >> $GITHUB_STEP_SUMMARY
+            fi
           fi

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write  # Required to push tags and create releases
 

--- a/src/agent_scorecard/dependencies.py
+++ b/src/agent_scorecard/dependencies.py
@@ -27,7 +27,7 @@ def _is_analyzable_file(filename: str) -> bool:
 def _scan_directory(path: str) -> List[str]:
     """
     Recursively scans a directory for analyzable files (Python, Markdown),
-    ignoring hidden directories.
+    ignoring hidden directories, node_modules, and virtual environments.
 
     Args:
         path (str): The directory to scan.
@@ -36,10 +36,14 @@ def _scan_directory(path: str) -> List[str]:
         List[str]: List of absolute paths to analyzable files.
     """
     analyzable_files = []
-    for root, _, files in os.walk(path):
-        parts = root.split(os.sep)
-        if any(p.startswith(".") and p != "." for p in parts):
-            continue
+    for root, dirs, files in os.walk(path):
+        # Prune unwanted directories in-place to avoid unnecessary traversal
+        dirs[:] = [
+            d
+            for d in dirs
+            if not d.startswith(".") and d not in ("node_modules", "venv", ".venv")
+        ]
+
         for file in files:
             if _is_analyzable_file(file):
                 analyzable_files.append(os.path.join(root, file))

--- a/src/agent_scorecard/main.py
+++ b/src/agent_scorecard/main.py
@@ -355,6 +355,12 @@ def fix(path: str, agent: str) -> None:
     is_flag=True,
     help="Filter results to show only failing files (score < 70).",
 )
+@click.option(
+    "--fail-under",
+    type=int,
+    default=70,
+    help="Fail if the final score is below this threshold (default: 70).",
+)
 def score(
     path: str,
     agent: str,
@@ -369,6 +375,7 @@ def score(
     sort: str,
     top: Optional[int],
     failing: bool,
+    fail_under: int,
 ) -> None:
     """
     Scores a codebase based on agent compatibility.
@@ -503,7 +510,7 @@ def score(
         with open(report_path, "w", encoding="utf-8") as f:
             f.write(content)
 
-    if results["final_score"] < 70 or results.get("project_issues"):
+    if results["final_score"] < fail_under or results.get("project_issues"):
         sys.exit(1)
 
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -30,6 +30,23 @@ def test_collect_python_files(tmp_path: Path) -> None:
     assert any(f.endswith("root.py") for f in files)
 
 
+def test_collect_files_pruning(tmp_path: Path) -> None:
+    """
+    Tests that node_modules, .venv, etc. are pruned.
+    """
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "bad.py").write_text("print('no')")
+
+    (tmp_path / ".venv").mkdir()
+    (tmp_path / ".venv" / "bad2.py").write_text("print('no')")
+
+    (tmp_path / "good.py").write_text("print('yes')")
+
+    files = collect_python_files(str(tmp_path))
+    assert len(files) == 1
+    assert files[0].endswith("good.py")
+
+
 def test_import_graph_and_cycles(tmp_path: Path) -> None:
     """
     Tests import graph generation and cycle detection.


### PR DESCRIPTION
This PR refactors the branch enforcement and quality gate logic to support a multi-stage release cycle (Main -> Beta -> Stable). 

Key changes:
- **Dynamic Enforcement**: `agent-gatekeeper.yaml` now uses `${{ github.base_ref }}` and `${{ github.event.pull_request.base.ref }}` to apply branch-specific policies.
- **Tiered Quality Gates**: 
    - PRs to `main` require an Agent Scorecard pass of >= 90, must originate from `beta`, and require at least one approval.
    - PRs to `beta` require a Scorecard pass of >= 70 and verify that `node_modules` pruning fixes are implemented in the scanner.
- **CLI Enhancements**: Added a `--fail-under` flag to the `agent-score score` command to allow CI/CD to enforce specific score thresholds.
- **Scanner Optimization**: Updated `src/agent_scorecard/dependencies.py` to efficiently prune `node_modules`, `venv`, and other environment directories during scanning.
- **Governance**: Restricted `manual-release.yaml` to only execute on the `main` branch.
- **UX**: Improved Action logs with `::group::` commands and detailed failure explanations in the GitHub Step Summary.

Fixes #264

---
*PR created automatically by Jules for task [12050342033220337488](https://jules.google.com/task/12050342033220337488) started by @brewmarsh*