### PR TITLE
Migrate to PythonAnalyzer instance methods to fix DeprecationWarning test failures

### DIFF
--- a/src/agent_scorecard/fix.py
+++ b/src/agent_scorecard/fix.py
@@ -4,7 +4,7 @@ import re
 from typing import Dict, Any, List, Optional
 from rich.console import Console
 from .constants import AGENT_CONTEXT_TEMPLATE, INSTRUCTIONS_TEMPLATE
-from .metrics import get_function_stats
+from .analyzers.python import PythonAnalyzer
 from .llm import LLMClient
 
 console = Console()
@@ -53,7 +53,7 @@ def fix_file_issues(filepath: str, llm_config: Optional[Dict[str, Any]] = None) 
         None
     """
     try:
-        stats = get_function_stats(filepath)
+        stats = PythonAnalyzer().get_function_stats(filepath)
     except Exception:
         return
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1,7 +1,6 @@
 import textwrap
 from pathlib import Path
-from agent_scorecard.analyzer import calculate_acl
-from agent_scorecard.scoring import score_file
+from agent_scorecard.analyzers.python import PythonAnalyzer
 from agent_scorecard.constants import PROFILES
 
 
@@ -19,21 +18,21 @@ def test_acl_calculation_logic() -> None:
     loc = 20
     depth = 0
     # ACL = (0*2) + (1*1.5) + (20/50) = 1.5 + 0.4 = 1.9
-    assert calculate_acl(cc, loc, depth) == 1.9
+    assert PythonAnalyzer().calculate_acl(cc, loc, depth) == 1.9
 
     # Case 2: Complex file (Medium complexity, medium length, depth 5)
     cc = 10.0
     loc = 100
     depth = 5
     # ACL = (5*2) + (10*1.5) + (100/50) = 10 + 15 + 2 = 27.0
-    assert calculate_acl(cc, loc, depth) == 27.0
+    assert PythonAnalyzer().calculate_acl(cc, loc, depth) == 27.0
 
     # Case 3: High ACL (High complexity, high length, depth 0)
     cc = 10.0
     loc = 200
     depth = 0
     # ACL = (0*2) + (10*1.5) + (200/50) = 15 + 4 = 19.0
-    assert calculate_acl(cc, loc, depth) == 19.0
+    assert PythonAnalyzer().calculate_acl(cc, loc, depth) == 19.0
 
 
 def test_scoring_with_acl_penalty(tmp_path: Path) -> None:
@@ -69,7 +68,7 @@ def test_scoring_with_acl_penalty(tmp_path: Path) -> None:
     py_file.write_text(content, encoding="utf-8")
 
     # Score the file using the generic agent profile
-    score, details, loc, avg_comp, type_cov, func_metrics = score_file(
+    score, details, loc, avg_comp, type_cov, func_metrics = PythonAnalyzer().score_file(
         str(py_file), PROFILES["generic"]
     )
 

--- a/tests/test_acl_refactor_verification.py
+++ b/tests/test_acl_refactor_verification.py
@@ -1,6 +1,6 @@
 import textwrap
 from pathlib import Path
-from agent_scorecard.analyzer import get_function_stats
+from agent_scorecard.analyzers.python import PythonAnalyzer
 
 
 def test_acl_formula_favor_flat_long_over_short_nested(tmp_path: Path) -> None:
@@ -35,8 +35,8 @@ def test_acl_formula_favor_flat_long_over_short_nested(tmp_path: Path) -> None:
     nested_file = tmp_path / "nested.py"
     nested_file.write_text(short_nested_code, encoding="utf-8")
 
-    flat_metrics = get_function_stats(str(flat_file))
-    nested_metrics = get_function_stats(str(nested_file))
+    flat_metrics = PythonAnalyzer().get_function_stats(str(flat_file))
+    nested_metrics = PythonAnalyzer().get_function_stats(str(nested_file))
 
     flat_acl = flat_metrics[0]["acl"]
     nested_acl = nested_metrics[0]["acl"]

--- a/tests/test_advisor.py
+++ b/tests/test_advisor.py
@@ -1,11 +1,9 @@
 import textwrap
 from pathlib import Path
-from agent_scorecard import analyzer, report
+from agent_scorecard import report
 from agent_scorecard.constants import PROFILES
-from agent_scorecard.analyzer import (
-    calculate_acl,
-    get_import_graph,
-)
+from agent_scorecard.analyzer import get_import_graph
+from agent_scorecard.analyzers.python import PythonAnalyzer
 from agent_scorecard.dependencies import (
     get_inbound_imports,
     detect_cycles,
@@ -25,8 +23,8 @@ def test_calculate_acl() -> None:
         None
     """
     # cc=10, loc=100, depth=5 -> (5*2) + (10*1.5) + (100/50) = 10 + 15 + 2 = 27.0
-    assert calculate_acl(10, 100, 5) == 27.0
-    assert calculate_acl(0, 0, 0) == 0
+    assert PythonAnalyzer().calculate_acl(10, 100, 5) == 27.0
+    assert PythonAnalyzer().calculate_acl(0, 0, 0) == 0
 
 
 def test_get_directory_entropy(tmp_path: Path) -> None:
@@ -164,7 +162,7 @@ def test_function_stats_parsing(tmp_path: Path) -> None:
     p = tmp_path / "test_acl.py"
     p.write_text(code, encoding="utf-8")
 
-    stats = analyzer.get_function_stats(str(p))
+    stats = PythonAnalyzer().get_function_stats(str(p))
     assert len(stats) == 1
     func = stats[0]
     assert func["name"] == "complex_function"
@@ -192,7 +190,7 @@ def test_unified_score_report_content(tmp_path: Path) -> None:
 
     (tmp_path / "hallucination.py").write_text(code, encoding="utf-8")
 
-    func_stats = analyzer.get_function_stats(str(tmp_path / "hallucination.py"))
+    func_stats = PythonAnalyzer().get_function_stats(str(tmp_path / "hallucination.py"))
     acl_violations = [f for f in func_stats if f["acl"] > 15]
 
     stats = [

--- a/tests/test_analyzer_new.py
+++ b/tests/test_analyzer_new.py
@@ -1,6 +1,6 @@
 import textwrap
 from pathlib import Path
-from agent_scorecard.analyzer import get_function_stats, calculate_max_depth
+from agent_scorecard.analyzers.python import PythonAnalyzer
 
 
 def test_calculate_max_depth() -> None:
@@ -16,7 +16,7 @@ def test_calculate_max_depth() -> None:
     """
     # Flat function
     code1 = "def foo(): pass"
-    assert calculate_max_depth(code1) == 0
+    assert PythonAnalyzer().calculate_max_depth(code1) == 0
 
     # Example from prompt
     code2 = textwrap.dedent(
@@ -28,7 +28,7 @@ def test_calculate_max_depth() -> None:
                     print(item)
     """
     )
-    assert calculate_max_depth(code2) == 3
+    assert PythonAnalyzer().calculate_max_depth(code2) == 3
 
     # Nested Try/Except/Finally
     code3 = textwrap.dedent(
@@ -42,12 +42,12 @@ def test_calculate_max_depth() -> None:
         pass
     """
     )
-    assert calculate_max_depth(code3) == 2
+    assert PythonAnalyzer().calculate_max_depth(code3) == 2
 
     # List comprehension and lambda
     code4 = "x = [lambda y: [i for i in range(y)] for y in range(10)]"
     # ListComp -> Lambda -> ListComp = 3
-    assert calculate_max_depth(code4) == 3
+    assert PythonAnalyzer().calculate_max_depth(code4) == 3
 
     # Deep nesting with mixed types
     code5 = textwrap.dedent(
@@ -60,7 +60,7 @@ def test_calculate_max_depth() -> None:
                         pass
     """
     )
-    assert calculate_max_depth(code5) == 5
+    assert PythonAnalyzer().calculate_max_depth(code5) == 5
 
     # Async variants
     code6 = textwrap.dedent(
@@ -71,7 +71,7 @@ def test_calculate_max_depth() -> None:
                 pass
     """
     )
-    assert calculate_max_depth(code6) == 2
+    assert PythonAnalyzer().calculate_max_depth(code6) == 2
 
 
 def test_get_function_stats(tmp_path: Path) -> None:
@@ -129,7 +129,7 @@ def test_get_function_stats(tmp_path: Path) -> None:
     p.write_text(code, encoding="utf-8")
 
     # Analyzer expects a string path; convert from pathlib.Path object
-    stats = get_function_stats(str(p))
+    stats = PythonAnalyzer().get_function_stats(str(p))
     assert len(stats) == 3
 
     simple_func = next(s for s in stats if s["name"] == "simple")

--- a/tests/test_async_support.py
+++ b/tests/test_async_support.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import textwrap
 from click.testing import CliRunner
 from agent_scorecard.main import cli
-from agent_scorecard.analyzer import check_type_hints
+from agent_scorecard.analyzers.python import PythonAnalyzer
 
 
 def test_async_function_support_checks(tmp_path: Path) -> None:
@@ -25,7 +25,7 @@ async def fetch_data(url):
     )
 
     # Should find 1 function, 0 typed -> 0% coverage.
-    cov = check_type_hints(str(p))
+    cov = PythonAnalyzer().check_type_hints(str(p))
     assert cov == 0
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3,10 +3,9 @@ from pathlib import Path
 from click.testing import CliRunner
 
 # RESOLUTION: Import from the correct modules (analyzer/scoring) as per the architectural cleanup
-from agent_scorecard import analyzer
 from agent_scorecard.constants import PROFILES
 from agent_scorecard.main import cli
-from agent_scorecard.scoring import score_file
+from agent_scorecard.analyzers.python import PythonAnalyzer
 
 
 def test_get_loc(tmp_path: Path) -> None:
@@ -26,7 +25,7 @@ def test_get_loc(tmp_path: Path) -> None:
     py_file.write_text(content, encoding="utf-8")
 
     # Ensure internal logic handles string paths for cross-OS compatibility
-    loc = analyzer.get_loc(str(py_file))
+    loc = PythonAnalyzer()._get_loc(str(py_file))
     assert loc == 10
 
 
@@ -56,7 +55,7 @@ def test_get_function_stats(tmp_path: Path) -> None:
     py_file.write_text(content, encoding="utf-8")
 
     # RESOLUTION: Use unified get_function_stats API
-    metrics = analyzer.get_function_stats(str(py_file))
+    metrics = PythonAnalyzer().get_function_stats(str(py_file))
     assert len(metrics) == 2
 
     simple = next(m for m in metrics if m["name"] == "simple_func")
@@ -99,8 +98,8 @@ def untyped_function(a, b):
     untyped_file = tmp_path / "untyped.py"
     untyped_file.write_text(untyped_content, encoding="utf-8")
 
-    typed_coverage = analyzer.check_type_hints(str(typed_file))
-    untyped_coverage = analyzer.check_type_hints(str(untyped_file))
+    typed_coverage = PythonAnalyzer().check_type_hints(str(typed_file))
+    untyped_coverage = PythonAnalyzer().check_type_hints(str(untyped_file))
 
     assert typed_coverage == 100
     assert untyped_coverage == 0
@@ -128,7 +127,7 @@ def test_score_file_logic(tmp_path: Path) -> None:
     profile = PROFILES["generic"]
 
     # RESOLUTION: Updated score_file return signature (6-tuple) from Beta branch
-    score, issues, loc, complexity, type_safety, metrics = score_file(
+    score, issues, loc, complexity, type_safety, metrics = PythonAnalyzer().score_file(
         str(py_file), profile
     )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,7 @@
 import pytest
 from pathlib import Path
-from agent_scorecard.analyzer import (
-    get_loc,
-    get_complexity_score,  # Renamed from analyze_complexity
-    check_type_hints,  # Renamed from analyze_type_hints
-    scan_project_docs,
-)
+from agent_scorecard.analyzer import scan_project_docs
+from agent_scorecard.analyzers.python import PythonAnalyzer
 from agent_scorecard.scoring import generate_badge
 
 
@@ -70,7 +66,7 @@ def test_get_loc(sample_file: Path) -> None:
     Returns:
         None
     """
-    assert get_loc(str(sample_file)) == 8
+    assert PythonAnalyzer()._get_loc(str(sample_file)) == 8
 
 
 def test_analyze_complexity(sample_file: Path) -> None:
@@ -83,7 +79,7 @@ def test_analyze_complexity(sample_file: Path) -> None:
     Returns:
         None
     """
-    avg = get_complexity_score(str(sample_file))
+    avg = PythonAnalyzer().get_complexity_score(str(sample_file))
     assert avg == 2.5
 
     # Penalty Logic Simulation (threshold=10)
@@ -106,7 +102,7 @@ def test_check_type_hints(sample_file: Path, typed_file: Path) -> None:
     Returns:
         None
     """
-    cov = check_type_hints(str(sample_file))
+    cov = PythonAnalyzer().check_type_hints(str(sample_file))
     assert cov == 0
 
     # Penalty Logic Simulation (threshold=50)
@@ -114,7 +110,7 @@ def test_check_type_hints(sample_file: Path, typed_file: Path) -> None:
     assert penalty == 20
 
     # typed_file: 1/1 typed -> 100%
-    cov = check_type_hints(str(typed_file))
+    cov = PythonAnalyzer().check_type_hints(str(typed_file))
     assert cov == 100
 
     # Penalty Logic Simulation (threshold=50)

--- a/tests/test_regression_guard.py
+++ b/tests/test_regression_guard.py
@@ -1,7 +1,7 @@
 import textwrap
 import pytest
 from pathlib import Path
-from agent_scorecard.scoring import score_file
+from agent_scorecard.analyzers.python import PythonAnalyzer
 from agent_scorecard.constants import PROFILES
 from agent_scorecard import analyzer
 
@@ -21,7 +21,7 @@ def test_bloated_files_penalty(tmp_path: Path) -> None:
     py_file = tmp_path / "bloated.py"
     py_file.write_text(content, encoding="utf-8")
 
-    score, details, loc, avg_comp, type_cov, metrics = score_file(
+    score, details, loc, avg_comp, type_cov, metrics = PythonAnalyzer().score_file(
         str(py_file), PROFILES["generic"]
     )
 
@@ -59,7 +59,7 @@ def test_acl_strictness(tmp_path: Path) -> None:
     py_file = tmp_path / "high_acl.py"
     py_file.write_text(content, encoding="utf-8")
 
-    score, details, loc, avg_comp, type_cov, metrics = score_file(
+    score, details, loc, avg_comp, type_cov, metrics = PythonAnalyzer().score_file(
         str(py_file), PROFILES["generic"]
     )
 

--- a/tests/test_scoring_acl.py
+++ b/tests/test_scoring_acl.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from click.testing import CliRunner
-from agent_scorecard.scoring import score_file
+from agent_scorecard.analyzers.python import PythonAnalyzer
 from agent_scorecard.constants import PROFILES
 from agent_scorecard.main import cli
 
@@ -43,7 +43,7 @@ def test_score_file_acl_penalty(tmp_path: Path) -> None:
     # 3. Bloated File: 328 LOC - 200 threshold = 128. Penalty (1 per 10 lines): -12.
     # Total Score: 100 - 15 - 20 - 12 = 53.
 
-    score, details, loc, avg_comp, type_cov, metrics = score_file(
+    score, details, loc, avg_comp, type_cov, metrics = PythonAnalyzer().score_file(
         str(p), PROFILES["generic"]
     )
 


### PR DESCRIPTION
The `pytest -W error` test suite was failing due to `DeprecationWarning`s caused by using old standalone module functions (e.g., `calculate_acl`, `score_file`, `get_function_stats`) from `agent_scorecard.analyzer`, `agent_scorecard.scoring`, and `agent_scorecard.metrics`. 
This commit updates the tests and `src/agent_scorecard/fix.py` to import and instantiate `PythonAnalyzer` from `agent_scorecard.analyzers.python`, calling its corresponding methods to eliminate the warnings and align with the new object-oriented architectural pattern.

---
*PR created automatically by Jules for task [14772865225989617492](https://jules.google.com/task/14772865225989617492) started by @brewmarsh*