### PR TITLE
fix hatchling build for src-layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ source = "vcs"
 [tool.hatch.build.hooks.vcs]
 version-file = "src/agent_scorecard/_version.py"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/agent_scorecard"]
+sources = ["src"]
+
 [tool.agent-scorecard]
 agent = "generic"
 verbosity = "summary"

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "agent-scorecard"
+name = "agent-readiness-scorecard"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixed the Hatchling build configuration in `pyproject.toml` to correctly handle the "src-layout". Added `[tool.hatch.build.targets.wheel]` with `packages = ["src/agent_scorecard"]` and `sources = ["src"]` to ensure the package is installed at the root of `site-packages` without a nested `src` folder. Verified the fix by building the wheel and inspecting its contents, and confirmed no regressions by running the full test suite.

Fixes #297

---
*PR created automatically by Jules for task [9712803384721297218](https://jules.google.com/task/9712803384721297218) started by @brewmarsh*