### PR TITLE
fix: update markdown report title to use Agent Readiness Scorecard

### DIFF
--- a/src/agent_readiness_scorecard/report.py
+++ b/src/agent_readiness_scorecard/report.py
@@ -15,7 +15,7 @@ def _generate_summary_section(
     """
     Creates the executive summary section of the report.
     """
-    summary = f"# Agent Scorecard Report v{version}\n\n"
+    summary = f"# Agent Readiness Scorecard Report v{version}\n\n"
     profile_desc = profile.get("description", "Generic").split(".")[0]
     summary += f"**Target Agent Profile:** {profile_desc}\n"
     status_str = "PASS" if final_score >= 70 else "FAIL"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -63,7 +63,7 @@ def test_generate_markdown_report() -> None:
     )
 
     # Core Content Verification
-    assert "# Agent Scorecard Report v" in report_content
+    assert "# Agent Readiness Scorecard Report v" in report_content
     assert "Overall Score: 70.0/100" in report_content
     assert "PASSED" in report_content
 


### PR DESCRIPTION
The previous PR that renamed the project to "Agent Readiness Scorecard" missed updating the generated markdown report header string (which was concurrently modified to include version numbers in another PR). This led to test failures in `test_advisor.py`, `test_logic.py`, `test_report_full.py`, and `test_report.py`. This commit updates the report generation string to correctly use "Agent Readiness Scorecard Report" and updates the tests to match, ensuring the CI pipeline passes correctly.

---
*PR created automatically by Jules for task [1389798702749619873](https://jules.google.com/task/1389798702749619873) started by @brewmarsh*