### PR TITLE
Improve Analyzer Robustness for Optional Dependencies

### DIFF
--- a/src/agent_readiness_scorecard/analyzers/config.py
+++ b/src/agent_readiness_scorecard/analyzers/config.py
@@ -15,9 +15,13 @@ except ImportError:
     except ImportError:
         toml_parser = None  # type: ignore
 
+from rich.console import Console
 from .base import BaseAnalyzer
 from ..types import FunctionMetric
 from ..constants import DEFAULT_THRESHOLDS
+
+WARN_YAML = False
+WARN_TOML = False
 
 
 class ConfigAnalyzer(BaseAnalyzer):
@@ -73,6 +77,9 @@ class ConfigAnalyzer(BaseAnalyzer):
             # Check if it was a parsing error
             try:
                 self._parse_config(filepath)
+            except ImportError as e:
+                details.append(f"Missing dependency: {str(e)}")
+                return max(score, 0), ", ".join(details), loc, 0.0, 100.0, []
             except Exception:
                 score -= 20
                 details.append("Malformed Configuration File (-20)")
@@ -163,12 +170,26 @@ class ConfigAnalyzer(BaseAnalyzer):
             if yaml:
                 return yaml.safe_load(content)
             else:
-                raise ImportError("PyYAML not installed")
+                global WARN_YAML
+                if not WARN_YAML:
+                    console = Console()
+                    console.print(
+                        "[yellow]Warning: PyYAML not found. YAML analysis will be skipped.[/yellow]"
+                    )
+                    WARN_YAML = True
+                raise ImportError("PyYAML")
         elif ext == ".toml":
             if toml_parser:
                 return toml_parser.loads(content)
             else:
-                raise ImportError("TOML parser not available")
+                global WARN_TOML
+                if not WARN_TOML:
+                    console = Console()
+                    console.print(
+                        "[yellow]Warning: TOML parser not found. TOML analysis will be skipped.[/yellow]"
+                    )
+                    WARN_TOML = True
+                raise ImportError("tomli or tomllib")
         else:
             raise ValueError(f"Unsupported extension: {ext}")
 

--- a/src/agent_readiness_scorecard/analyzers/javascript.py
+++ b/src/agent_readiness_scorecard/analyzers/javascript.py
@@ -1,16 +1,30 @@
 from typing import Dict, Any, List, Tuple, Optional
-from tree_sitter import Language, Parser, Node
-import tree_sitter_javascript
-import tree_sitter_typescript
+try:
+    from tree_sitter import Language, Parser, Node
+    import tree_sitter_javascript
+    import tree_sitter_typescript
+    HAS_TREESITTER = True
+except ImportError:
+    HAS_TREESITTER = False
+    # Stub for typing if missing
+    class Node: pass  # type: ignore
 
+from rich.console import Console
 from .base import BaseAnalyzer
 from ..types import FunctionMetric
 from ..constants import DEFAULT_THRESHOLDS
 
 # Initialize languages
-JS_LANGUAGE = Language(tree_sitter_javascript.language())
-TS_LANGUAGE = Language(tree_sitter_typescript.language_typescript())
-TSX_LANGUAGE = Language(tree_sitter_typescript.language_tsx())
+if HAS_TREESITTER:
+    JS_LANGUAGE = Language(tree_sitter_javascript.language())
+    TS_LANGUAGE = Language(tree_sitter_typescript.language_typescript())
+    TSX_LANGUAGE = Language(tree_sitter_typescript.language_tsx())
+else:
+    JS_LANGUAGE = None
+    TS_LANGUAGE = None
+    TSX_LANGUAGE = None
+
+WARN_TREESITTER = False
 
 
 class JavascriptAnalyzer(BaseAnalyzer):
@@ -40,6 +54,20 @@ class JavascriptAnalyzer(BaseAnalyzer):
         """
         Calculates score based on the selected profile and Agent Readiness spec.
         """
+        loc = self._get_loc(filepath)
+        if not HAS_TREESITTER:
+            global WARN_TREESITTER
+            if not WARN_TREESITTER:
+                console = Console()
+                console.print(
+                    "[yellow]Warning: tree-sitter not found. JS/TS analysis will be skipped.[/yellow]"
+                )
+                console.print(
+                    "[yellow]Hint: Install the 'treesitter' extra: pip install agent-readiness-scorecard[treesitter][/yellow]"
+                )
+                WARN_TREESITTER = True
+            return (0, "Missing dependencies: Install [treesitter] extra", loc, 0.0, 100.0, [])
+
         p_thresholds = profile.get("thresholds", {})
         if thresholds is None:
             thresholds = self._get_default_thresholds(p_thresholds)
@@ -173,6 +201,9 @@ class JavascriptAnalyzer(BaseAnalyzer):
         """
         Returns statistics for each function in the file using tree-sitter.
         """
+        if not HAS_TREESITTER:
+            return []
+
         try:
             with open(filepath, "rb") as f:
                 source_bytes = f.read()

--- a/src/agent_readiness_scorecard/analyzers/markdown.py
+++ b/src/agent_readiness_scorecard/analyzers/markdown.py
@@ -1,8 +1,17 @@
-import tiktoken
+try:
+    import tiktoken
+    HAS_TIKTOKEN = True
+except ImportError:
+    HAS_TIKTOKEN = False
+
 from typing import Dict, Any, List, Tuple, Optional
+from rich.console import Console
 from .base import BaseAnalyzer
 from ..types import FunctionMetric
 from ..constants import DEFAULT_THRESHOLDS
+
+
+WARN_TIKTOKEN = False
 
 
 class MarkdownAnalyzer(BaseAnalyzer):
@@ -43,6 +52,19 @@ class MarkdownAnalyzer(BaseAnalyzer):
 
         score = 100
         details = []
+
+        if not HAS_TIKTOKEN:
+            global WARN_TIKTOKEN
+            if not WARN_TIKTOKEN:
+                console = Console()
+                console.print(
+                    "[yellow]Warning: tiktoken not found. Markdown token analysis will use a heuristic.[/yellow]"
+                )
+                console.print(
+                    "[yellow]Hint: Install tiktoken for better accuracy: pip install tiktoken[/yellow]"
+                )
+                WARN_TIKTOKEN = True
+            details.append("Missing dependency: tiktoken (using heuristic)")
 
         # Markdown bloat penalty: > 500 lines
         if loc > 500:
@@ -106,7 +128,8 @@ class MarkdownAnalyzer(BaseAnalyzer):
             return []
 
         stats: List[FunctionMetric] = []
-        enc = tiktoken.get_encoding("cl100k_base")
+        if HAS_TIKTOKEN:
+            enc = tiktoken.get_encoding("cl100k_base")
 
         sections = []
         current_header = None
@@ -136,7 +159,11 @@ class MarkdownAnalyzer(BaseAnalyzer):
 
         for header, lineno, content_lines in sections:
             content = "".join(content_lines)
-            tokens = len(enc.encode(content))
+            if HAS_TIKTOKEN:
+                tokens = len(enc.encode(content))
+            else:
+                # Heuristic: approx 4 characters per token
+                tokens = len(content) // 4
 
             # Nesting depth is the number of # symbols
             nesting_depth = 0

--- a/src/agent_readiness_scorecard/analyzers/python.py
+++ b/src/agent_readiness_scorecard/analyzers/python.py
@@ -1,6 +1,12 @@
 import ast
-import mccabe
+try:
+    import mccabe
+    HAS_MCCABE = True
+except ImportError:
+    HAS_MCCABE = False
+
 from typing import Dict, Any, List, Tuple, Optional
+from rich.console import Console
 from .base import BaseAnalyzer
 from ..types import FunctionMetric
 from ..constants import DEFAULT_THRESHOLDS
@@ -59,6 +65,9 @@ class NestingDepthVisitor(ast.NodeVisitor):
         self._visit_control_block(node)
 
 
+WARN_MCCABE = False
+
+
 class PythonAnalyzer(BaseAnalyzer):
     """
     Python-specific implementation of the BaseAnalyzer.
@@ -99,6 +108,16 @@ class PythonAnalyzer(BaseAnalyzer):
 
         score = 100
         details = []
+
+        if not HAS_MCCABE:
+            global WARN_MCCABE
+            if not WARN_MCCABE:
+                console = Console()
+                console.print(
+                    "[yellow]Warning: mccabe not found. Python complexity analysis will be skipped.[/yellow]"
+                )
+                WARN_MCCABE = True
+            details.append("Missing dependency: mccabe (complexity skipped)")
 
         if loc > 200:
             bloat_penalty = (loc - 200) // 10
@@ -168,11 +187,13 @@ class PythonAnalyzer(BaseAnalyzer):
         except (SyntaxError, UnicodeDecodeError, FileNotFoundError):
             return []
 
-        visitor = mccabe.PathGraphingAstVisitor()
-        visitor.preorder(tree, visitor)
-        complexity_map = {
-            graph.lineno: graph.complexity() for graph in visitor.graphs.values()
-        }
+        complexity_map = {}
+        if HAS_MCCABE:
+            visitor = mccabe.PathGraphingAstVisitor()
+            visitor.preorder(tree, visitor)
+            complexity_map = {
+                graph.lineno: graph.complexity() for graph in visitor.graphs.values()
+            }
 
         stats: List[FunctionMetric] = []
         for node in ast.walk(tree):
@@ -230,6 +251,9 @@ class PythonAnalyzer(BaseAnalyzer):
             tree = ast.parse(code, filepath)
         except (SyntaxError, UnicodeDecodeError, FileNotFoundError):
             return 0.0
+
+        if not HAS_MCCABE:
+            return 1.0
 
         visitor = mccabe.PathGraphingAstVisitor()
         visitor.preorder(tree, visitor)

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -1,0 +1,100 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import importlib
+import sys
+import os
+
+from agent_readiness_scorecard.analyzers.javascript import JavascriptAnalyzer
+import agent_readiness_scorecard.analyzers.javascript as js_module
+
+from agent_readiness_scorecard.analyzers.markdown import MarkdownAnalyzer
+import agent_readiness_scorecard.analyzers.markdown as md_module
+
+from agent_readiness_scorecard.analyzers.config import ConfigAnalyzer
+import agent_readiness_scorecard.analyzers.config as config_module
+
+from agent_readiness_scorecard.analyzers.python import PythonAnalyzer
+import agent_readiness_scorecard.analyzers.python as py_module
+
+def test_javascript_analyzer_no_treesitter(tmp_path):
+    js_file = tmp_path / "test.js"
+    js_file.write_text("console.log('hello');")
+
+    analyzer = JavascriptAnalyzer()
+
+    with patch("agent_readiness_scorecard.analyzers.javascript.HAS_TREESITTER", False):
+        # We also need to reset the warning flag to test the output if we wanted,
+        # but here we just check the return value.
+        with patch("agent_readiness_scorecard.analyzers.javascript.WARN_TREESITTER", False):
+            score, issues, loc, complexity, type_safety, metrics = analyzer.score_file(
+                str(js_file), {"thresholds": {}}
+            )
+
+            assert score == 0
+            assert "Missing dependencies: Install [treesitter] extra" in issues
+            assert loc > 0
+            assert metrics == []
+
+def test_markdown_analyzer_no_tiktoken(tmp_path):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("# Title\nSome content here.")
+
+    analyzer = MarkdownAnalyzer()
+
+    with patch("agent_readiness_scorecard.analyzers.markdown.HAS_TIKTOKEN", False):
+        with patch("agent_readiness_scorecard.analyzers.markdown.WARN_TIKTOKEN", False):
+            score, issues, loc, complexity, type_safety, metrics = analyzer.score_file(
+                str(md_file), {"thresholds": {}}
+            )
+
+            assert "Missing dependency: tiktoken (using heuristic)" in issues
+            # It should still have metrics because of the heuristic
+            assert len(metrics) > 0
+            assert metrics[0]["complexity"] > 0
+
+def test_config_analyzer_no_yaml(tmp_path):
+    yaml_file = tmp_path / "test.yaml"
+    yaml_file.write_text("key: value")
+
+    analyzer = ConfigAnalyzer()
+
+    with patch("agent_readiness_scorecard.analyzers.config.yaml", None):
+        with patch("agent_readiness_scorecard.analyzers.config.WARN_YAML", False):
+            score, issues, loc, complexity, type_safety, metrics = analyzer.score_file(
+                str(yaml_file), {"thresholds": {}}
+            )
+
+            assert "Missing dependency: PyYAML" in issues
+            assert metrics == []
+
+def test_config_analyzer_no_toml(tmp_path):
+    toml_file = tmp_path / "test.toml"
+    toml_file.write_text("key = 'value'")
+
+    analyzer = ConfigAnalyzer()
+
+    with patch("agent_readiness_scorecard.analyzers.config.toml_parser", None):
+        with patch("agent_readiness_scorecard.analyzers.config.WARN_TOML", False):
+            score, issues, loc, complexity, type_safety, metrics = analyzer.score_file(
+                str(toml_file), {"thresholds": {}}
+            )
+
+            assert "Missing dependency: tomli or tomllib" in issues
+            assert metrics == []
+
+def test_python_analyzer_no_mccabe(tmp_path):
+    py_file = tmp_path / "test.py"
+    py_file.write_text("def hello():\n    pass")
+
+    analyzer = PythonAnalyzer()
+
+    with patch("agent_readiness_scorecard.analyzers.python.HAS_MCCABE", False):
+        with patch("agent_readiness_scorecard.analyzers.python.WARN_MCCABE", False):
+            score, issues, loc, complexity, type_safety, metrics = analyzer.score_file(
+                str(py_file), {"thresholds": {}}
+            )
+
+            assert "Missing dependency: mccabe (complexity skipped)" in issues
+            assert len(metrics) > 0
+            # Complexity should be default 1.0
+            assert metrics[0]["complexity"] == 1.0


### PR DESCRIPTION
This submission improves the robustness of the `agent-readiness-scorecard` by ensuring that analyzers do not crash when optional dependencies are missing. Instead, they provide clear, actionable feedback to the user via one-time console warnings and descriptive issue messages in the report.

Key changes:
- **Javascript/Typescript**: Analysis is skipped if `tree-sitter` is missing, returning a 0 score with a "Missing dependencies" message.
- **Markdown**: Falls back to a character-based token heuristic if `tiktoken` is missing.
- **Python**: Complexity metrics are skipped (defaulting to 1.0) if `mccabe` is missing.
- **Config**: Gracefully handles missing `PyYAML` or TOML parsers.
- **Diagnostics**: One-time warnings are printed to the console using `rich` to alert the user about missing extras.
- **Testing**: A new robustness test suite verifies these behaviors using mocks.

Fixes #308

---
*PR created automatically by Jules for task [10509692770154842617](https://jules.google.com/task/10509692770154842617) started by @brewmarsh*