### PR TITLE
Fix Markdown Report Title and Missing Dependency Mock Tests

### DIFF
--- a/src/agent_readiness_scorecard/report.py
+++ b/src/agent_readiness_scorecard/report.py
@@ -15,7 +15,7 @@ def _generate_summary_section(
     """
     Creates the executive summary section of the report.
     """
-    summary = f"# Agent Scorecard Report v{version}\n\n"
+    summary = f"# Agent Readiness Scorecard Report v{version}\n\n"
     profile_desc = profile.get("description", "Generic").split(".")[0]
     summary += f"**Target Agent Profile:** {profile_desc}\n"
     status_str = "PASS" if final_score >= 70 else "FAIL"

--- a/tests/test_js_no_treesitter.py
+++ b/tests/test_js_no_treesitter.py
@@ -2,28 +2,39 @@ import sys
 import unittest
 from unittest.mock import patch
 
-# Mock tree-sitter before importing JavascriptAnalyzer
-with patch.dict(
-    sys.modules,
-    {
-        "tree_sitter": None,
-        "tree_sitter_javascript": None,
-        "tree_sitter_typescript": None,
-    },
-):
-    # Import inside the patch context
-    from agent_readiness_scorecard.analyzers.javascript import (
-        JavascriptAnalyzer,
-        HAS_TREESITTER,
-    )
-
-
 class TestJavascriptAnalyzerNoTreesitter(unittest.TestCase):
+    def setUp(self):
+        # We must delete the module from sys.modules to force a re-evaluation
+        # of the top-level try/except block.
+        for mod in list(sys.modules.keys()):
+            if "agent_readiness_scorecard.analyzers.javascript" in mod:
+                del sys.modules[mod]
+
+        self.patcher = patch.dict(
+            sys.modules,
+            {
+                "tree_sitter": None,
+                "tree_sitter_javascript": None,
+                "tree_sitter_typescript": None,
+            },
+        )
+        self.patcher.start()
+
+        import agent_readiness_scorecard.analyzers.javascript as js_analyzer_mod
+        self.analyzer_mod = js_analyzer_mod
+
+    def tearDown(self):
+        self.patcher.stop()
+        # Clean up so next tests can load the real module
+        for mod in list(sys.modules.keys()):
+            if "agent_readiness_scorecard.analyzers.javascript" in mod:
+                del sys.modules[mod]
+
     def test_has_treesitter_is_false(self) -> None:
-        self.assertFalse(HAS_TREESITTER)
+        self.assertFalse(self.analyzer_mod.HAS_TREESITTER)
 
     def test_score_file_no_treesitter(self) -> None:
-        analyzer = JavascriptAnalyzer()
+        analyzer = self.analyzer_mod.JavascriptAnalyzer()
         score, issues, loc, complexity, type_safety, metrics = analyzer.score_file(
             "test.js", {"thresholds": {}}, thresholds={}, cumulative_tokens=0
         )
@@ -35,10 +46,9 @@ class TestJavascriptAnalyzerNoTreesitter(unittest.TestCase):
         self.assertEqual(metrics, [])
 
     def test_get_function_stats_no_treesitter(self) -> None:
-        analyzer = JavascriptAnalyzer()
+        analyzer = self.analyzer_mod.JavascriptAnalyzer()
         stats = analyzer.get_function_stats("test.js")
         self.assertEqual(stats, [])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -63,7 +63,7 @@ def test_generate_markdown_report() -> None:
     )
 
     # Core Content Verification
-    assert "# Agent Scorecard Report v" in report_content
+    assert "# Agent Readiness Scorecard Report v" in report_content
     assert "Overall Score: 70.0/100" in report_content
     assert "PASSED" in report_content
 


### PR DESCRIPTION
Fixes failing tests related to report titles and mock isolation.
- Ensures the Markdown report header string matches assertions.
- Updates the mock strategy for optional dependencies to properly force top-level `ImportError` blocks to execute during the test suite.

---
*PR created automatically by Jules for task [12808099132029978859](https://jules.google.com/task/12808099132029978859) started by @brewmarsh*