### PR TITLE
Refactor report.py for lower Agent Cognitive Load (ACL)

### DIFF
--- a/src/agent_readiness_scorecard/report.py
+++ b/src/agent_readiness_scorecard/report.py
@@ -1,9 +1,18 @@
-from typing import List, Dict, Any, Optional, Union, cast
+from typing import List, Dict, Any, Optional, Union, cast, Tuple
 from .constants import DEFAULT_THRESHOLDS
 from .types import FileAnalysisResult, AdvisorFileResult, EnvironmentHealth
 from .remediation import generate_prompts_section, generate_recommendations_report
 
 __all__ = ["generate_recommendations_report", "generate_prompts_section"]
+
+
+def _get_status_message(final_score: float) -> str:
+    """
+    Returns the status message based on final score.
+    """
+    if final_score >= 70:
+        return "✅ **Status: PASSED** - This codebase is Agent-Ready.\n\n"
+    return "❌ **Status: FAILED** - This codebase needs improvement for AI Agents.\n\n"
 
 
 def _generate_summary_section(
@@ -15,25 +24,61 @@ def _generate_summary_section(
     """
     Creates the executive summary section of the report.
     """
-    summary = f"# Agent Readiness Scorecard Report v{version}\n\n"
     profile_desc = profile.get("description", "Generic").split(".")[0]
-    summary += f"**Target Agent Profile:** {profile_desc}\n"
     status_str = "PASS" if final_score >= 70 else "FAIL"
-    summary += f"**Overall Score: {final_score:.1f}/100** - {status_str}\n\n"
 
-    if final_score >= 70:
-        summary += "✅ **Status: PASSED** - This codebase is Agent-Ready.\n\n"
-    else:
-        summary += (
-            "❌ **Status: FAILED** - This codebase needs improvement for AI Agents.\n\n"
-        )
+    summary = [
+        f"# Agent Readiness Scorecard Report v{version}\n",
+        f"**Target Agent Profile:** {profile_desc}",
+        f"**Overall Score: {final_score:.1f}/100** - {status_str}\n",
+        _get_status_message(final_score),
+    ]
 
     if project_issues:
-        summary += "### ⚠️ Project Issues\n"
-        for issue in project_issues:
-            summary += f"- {issue}\n"
-        summary += "\n"
-    return summary
+        summary.append("### ⚠️ Project Issues")
+        summary.extend([f"- {issue}" for issue in project_issues])
+        summary.append("")
+
+    return "\n".join(summary)
+
+
+def _flatten_functions(
+    stats: Union[List[FileAnalysisResult], List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """
+    Flattens functions from file results into a single list.
+    """
+    all_functions = []
+    for f_res in stats:
+        metrics = f_res.get("function_metrics", [])
+        for m in metrics:
+            all_functions.append({**m, "file": f_res["file"]})
+    return all_functions
+
+
+def _get_sorted_high_acl_functions(
+    stats: Union[List[FileAnalysisResult], List[Dict[str, Any]]],
+    acl_yellow: float,
+    sort_by: str = "acl",
+    top_limit: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Flattens, filters and sorts functions by ACL.
+    """
+    all_functions = _flatten_functions(stats)
+
+    high_acl_functions = [
+        fn for fn in all_functions if cast(float, fn.get("acl", 0)) > acl_yellow
+    ]
+
+    sort_key = sort_by if sort_by in ["acl", "loc", "complexity"] else "acl"
+    sorted_funcs = sorted(
+        high_acl_functions, key=lambda x: x.get(sort_key, 0), reverse=True
+    )
+
+    if top_limit is not None:
+        return sorted_funcs[:top_limit]
+    return sorted_funcs
 
 
 def _generate_acl_section(
@@ -48,45 +93,40 @@ def _generate_acl_section(
     acl_yellow = thresholds.get("acl_yellow", DEFAULT_THRESHOLDS["acl_yellow"])
     acl_red = thresholds.get("acl_red", DEFAULT_THRESHOLDS["acl_red"])
 
-    targets = "## 🎯 Top Refactoring Targets (Agent Cognitive Load (ACL))\n\n"
-    # RESOLUTION: Adopted the high-fidelity formula focusing on nesting depth
-    targets += f"ACL = (Depth * 2) + (Complexity * 1.5) + (LOC / 50). Target: ACL <= {acl_yellow}.\n\n"
+    header = "## 🎯 Top Refactoring Targets (Agent Cognitive Load (ACL))\n\n"
+    header += f"ACL = (Depth * 2) + (Complexity * 1.5) + (LOC / 50). Target: ACL <= {acl_yellow}.\n\n"
 
-    all_functions = []
-    for f_res in stats:
-        metrics = f_res.get("function_metrics", [])
-        for m in metrics:
-            all_functions.append({**m, "file": f_res["file"]})
+    sorted_funcs = _get_sorted_high_acl_functions(stats, acl_yellow, sort_by, top_limit)
 
-    # --- SORTING & LIMITING ---
-    # Filter for functions that exceed the yellow threshold
-    high_acl_functions = [
-        fn for fn in all_functions if cast(float, fn.get("acl", 0)) > acl_yellow
-    ]
+    if not sorted_funcs:
+        return header + f"✅ All functions meet the Agent Cognitive Load (ACL) target of <= {acl_yellow}.\n\n"
 
-    # Support sorting by acl, loc, or complexity; default to acl
-    sort_key = sort_by if sort_by in ["acl", "loc", "complexity"] else "acl"
-    sorted_funcs = sorted(
-        high_acl_functions, key=lambda x: x.get(sort_key, 0), reverse=True
-    )
+    rows = ["| Function | File | ACL | Status |", "|----------|------|-----|--------|"]
+    for fn in sorted_funcs:
+        acl_val = cast(float, fn.get("acl", 0))
+        status = "🔴 Red" if acl_val > acl_red else "🟡 Yellow"
+        rows.append(f"| `{fn['name']}` | `{fn['file']}` | {acl_val:.1f} | {status} |")
 
-    if top_limit is not None:
-        sorted_funcs = sorted_funcs[:top_limit]
-    # --- END SORTING & LIMITING ---
+    return header + "\n".join(rows) + "\n\n"
 
-    if sorted_funcs:
-        targets += "| Function | File | ACL | Status |\n"
-        targets += "|----------|------|-----|--------|\n"
-        for fn in sorted_funcs:
-            acl_val = cast(float, fn.get("acl", 0))
-            status = "🔴 Red" if acl_val > acl_red else "🟡 Yellow"
-            targets += (
-                f"| `{fn['name']}` | `{fn['file']}` | {acl_val:.1f} | {status} |\n"
-            )
-        targets += "\n"
-    else:
-        targets += f"✅ All functions meet the Agent Cognitive Load (ACL) target of <= {acl_yellow}.\n\n"
-    return targets
+
+def _generate_type_safety_rows(
+    stats: Union[List[FileAnalysisResult], List[Dict[str, Any]]],
+    threshold: float,
+    verbosity: str,
+) -> List[str]:
+    """
+    Generates table rows for type safety.
+    """
+    sorted_types = sorted(stats, key=lambda x: x.get("type_coverage", 0))
+    table_rows = []
+    for res in sorted_types:
+        coverage = res.get("type_coverage", 0)
+        if verbosity == "summary" and coverage >= threshold:
+            continue
+        status = "✅" if coverage >= threshold else "❌"
+        table_rows.append(f"| {res['file']} | {coverage:.0f}% | {status} |")
+    return table_rows
 
 
 def _generate_type_safety_section(
@@ -101,29 +141,113 @@ def _generate_type_safety_section(
         "type_safety", DEFAULT_THRESHOLDS["type_safety"]
     )
 
-    types_section = "## 🛡️ Type Safety Index\n\n"
-    types_section += (
+    header = "## 🛡️ Type Safety Index\n\n"
+    header += (
         f"Target: >{type_safety_threshold}% of functions "
         "must have explicit type signatures.\n\n"
     )
 
-    sorted_types = sorted(stats, key=lambda x: x.get("type_coverage", 0))
-    table_rows = []
-    for res in sorted_types:
-        coverage = res.get("type_coverage", 0)
-        if verbosity == "summary" and coverage >= type_safety_threshold:
-            continue
-        status = "✅" if coverage >= type_safety_threshold else "❌"
-        table_rows.append(f"| {res['file']} | {coverage:.0f}% | {status} |")
+    table_rows = _generate_type_safety_rows(stats, type_safety_threshold, verbosity)
 
     if not table_rows:
-        return types_section + "✅ All files meet type safety requirements.\n\n"
+        return header + "✅ All files meet type safety requirements.\n\n"
 
-    types_section += "| File | Type Safety Index | Status |\n"
-    types_section += "| :--- | :---------------: | :----- |\n"
-    types_section += "\n".join(table_rows)
+    table_header = ["| File | Type Safety Index | Status |", "| :--- | :---------------: | :----- |"]
+    return header + "\n".join(table_header + table_rows) + "\n\n"
 
-    return types_section + "\n\n"
+
+def _group_files_by_language(
+    stats: Union[List[FileAnalysisResult], List[Dict[str, Any]]],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Groups analysis results by language.
+    """
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for res in stats:
+        lang = res.get("language", "Unknown")
+        if lang not in grouped:
+            grouped[lang] = []
+        grouped[lang].append(cast(Dict[str, Any], res))
+    return grouped
+
+
+def _generate_passing_details_detailed(passing: List[Dict[str, Any]], lang: str) -> str:
+    """
+    Generates detailed list of passing files.
+    """
+    rows = [
+        "\n<details>",
+        f"<summary>View {len(passing)} Passing {lang} Files</summary>\n",
+        "| File | Score | Issues |",
+        "| :--- | :---: | :--- |",
+    ]
+    for res in passing:
+        rows.append(f"| {res['file']} | {res['score']} ✅ | |")
+    rows.append("\n</details>\n")
+    return "\n".join(rows)
+
+
+def _generate_passing_details(
+    passing: List[Dict[str, Any]], lang: str, verbosity: str, has_failing: bool
+) -> str:
+    """
+    Generates details for passing files.
+    """
+    if verbosity == "detailed":
+        return _generate_passing_details_detailed(passing, lang)
+
+    if has_failing and verbosity == "summary":
+        return f"\n*Plus {len(passing)} passing files hidden.*\n"
+
+    return ""
+
+
+def _generate_failing_rows(failing: List[Dict[str, Any]]) -> List[str]:
+    """
+    Generates markdown table rows for failing files.
+    """
+    rows = ["| File | Score | Issues |", "| :--- | :---: | :--- |"]
+    for res in failing:
+        rows.append(f"| {res['file']} | {res['score']} ❌ | {res.get('issues', '')} |")
+    return rows
+
+
+def _generate_language_section(
+    lang: str, lang_files: List[Dict[str, Any]], verbosity: str
+) -> Optional[str]:
+    """
+    Generates a section for a specific language.
+    """
+    failing = [f for f in lang_files if f.get("score", 0) < 70]
+    passing = [f for f in lang_files if f.get("score", 0) >= 70]
+
+    if not failing and verbosity == "summary":
+        return None
+
+    lang_section = [f"#### {lang}"]
+    if failing:
+        lang_section.extend(_generate_failing_rows(failing))
+
+    if passing:
+        lang_section.append(
+            _generate_passing_details(passing, lang, verbosity, bool(failing))
+        )
+
+    return "\n".join(lang_section)
+
+
+def _generate_sections_by_language(
+    grouped: Dict[str, List[Dict[str, Any]]], verbosity: str
+) -> List[str]:
+    """
+    Generates report sections for each language.
+    """
+    sections = []
+    for lang in sorted(grouped.keys()):
+        section = _generate_language_section(lang, grouped[lang], verbosity)
+        if section:
+            sections.append(section)
+    return sections
 
 
 def _generate_file_table_section(
@@ -133,52 +257,14 @@ def _generate_file_table_section(
     """
     Creates a breakdown of analysis for every file grouped by language.
     """
-    if verbosity == "summary":
-        title = "### 📂 Failing File Analysis"
-    else:
-        title = "### 📂 Full File Analysis"
+    title = (
+        "### 📂 Failing File Analysis"
+        if verbosity == "summary"
+        else "### 📂 Full File Analysis"
+    )
 
-    # Group files by language
-    grouped: Dict[str, List[Dict[str, Any]]] = {}
-    for res in stats:
-        lang = res.get("language", "Unknown")
-        if lang not in grouped:
-            grouped[lang] = []
-        grouped[lang].append(cast(Dict[str, Any], res))
-
-    sections = []
-    for lang in sorted(grouped.keys()):
-        lang_files = grouped[lang]
-        failing = [f for f in lang_files if f.get("score", 0) < 70]
-        passing = [f for f in lang_files if f.get("score", 0) >= 70]
-
-        if not failing and verbosity == "summary":
-            continue
-
-        lang_section = [f"#### {lang}"]
-
-        if failing:
-            lang_section.append("| File | Score | Issues |")
-            lang_section.append("| :--- | :---: | :--- |")
-            for res in failing:
-                lang_section.append(
-                    f"| {res['file']} | {res['score']} ❌ | {res.get('issues', '')} |"
-                )
-
-        if passing and verbosity == "detailed":
-            lang_section.append("\n<details>")
-            lang_section.append(
-                f"<summary>View {len(passing)} Passing {lang} Files</summary>\n"
-            )
-            lang_section.append("| File | Score | Issues |")
-            lang_section.append("| :--- | :---: | :--- |")
-            for res in passing:
-                lang_section.append(f"| {res['file']} | {res['score']} ✅ | |")
-            lang_section.append("\n</details>\n")
-        elif passing and failing and verbosity == "summary":
-            lang_section.append(f"\n*Plus {len(passing)} passing files hidden.*\n")
-
-        sections.append("\n".join(lang_section))
+    grouped = _group_files_by_language(stats)
+    sections = _generate_sections_by_language(grouped, verbosity)
 
     if not sections and verbosity == "summary":
         return "### 📂 File Analysis\n\n✅ All files passed!\n"
@@ -262,6 +348,112 @@ def generate_markdown_report(
     )
 
 
+def _generate_advisor_acl_section(
+    stats: Union[List[AdvisorFileResult], List[Dict[str, Any]]],
+) -> str:
+    """
+    Generates the ACL section of the Advisor Report.
+    """
+    section = "## 1. Agent Cognitive Load (ACL)\n*Formula: ACL = (Depth * 2) + (Complexity * 1.5) + (LOC / 50)*\n\n"
+    high_acl_files = sorted(
+        [s for s in stats if s.get("acl", 0) > 15],
+        key=lambda x: x.get("acl", 0),
+        reverse=True,
+    )
+    if high_acl_files:
+        section += "### 🚨 Hallucination Zones (ACL > 15)\n| File | ACL | Complexity | LOC |\n|---|---|---|---|\n"
+        for s in high_acl_files:
+            section += f"| `{s['file']}` | **{s.get('acl', 0):.1f}** | {s.get('complexity', 0):.1f} | {s.get('loc', 0)} |\n"
+    else:
+        section += "✅ No Hallucination Zones detected.\n"
+    return section
+
+
+def _generate_advisor_tokens_section(
+    stats: Union[List[AdvisorFileResult], List[Dict[str, Any]]],
+) -> str:
+    """
+    Generates the Context Economics section of the Advisor Report.
+    """
+    section = "\n## 2. Context Economics\n"
+    high_token_files = [f for f in stats if f.get("tokens", 0) > 32000]
+    if high_token_files:
+        section += "### 🪙 Token Budget (> 32k tokens)\n"
+        for f in high_token_files:
+            section += f"- `{f['file']}`: {f.get('tokens', 0)} tokens\n"
+    else:
+        section += "✅ All files within context window limits.\n"
+    return section
+
+
+def _generate_god_modules_table(god_modules: List[Tuple[str, int]]) -> str:
+    """
+    Generates the god modules table.
+    """
+    section = "### 🕸 God Modules\n| File | Inbound Refs |\n|---|---|\n"
+    for k, v in god_modules:
+        section += f"| `{k}` | {v} |\n"
+    return section
+
+
+def _generate_cycles_list(cycles: List[List[str]]) -> str:
+    """
+    Generates the circular dependencies list.
+    """
+    section = "### 🔄 Circular Dependencies\n"
+    for cycle in cycles:
+        section += f"- {' -> '.join(cycle)} -> {cycle[0]}\n"
+    return section
+
+
+def _generate_advisor_dependency_section(
+    dependency_stats: Dict[str, int], cycles: List[List[str]]
+) -> str:
+    """
+    Generates the Dependency Entanglement section of the Advisor Report.
+    """
+    section = "\n## 3. Dependency Entanglement\n"
+    god_modules = sorted(
+        {k: v for k, v in dependency_stats.items() if v > 50}.items(),
+        key=lambda x: x[1],
+        reverse=True,
+    )
+    if god_modules:
+        section += _generate_god_modules_table(god_modules)
+
+    if cycles:
+        section += _generate_cycles_list(cycles)
+    else:
+        section += "✅ No Circular Dependencies detected.\n"
+    return section
+
+
+def _generate_crowded_dirs_list(crowded_dirs: Dict[str, int]) -> str:
+    """
+    Generates the list of crowded directories.
+    """
+    section = "### 📂 Crowded Directories (> 15 files)\n"
+    for p, c in crowded_dirs.items():
+        section += f"- `{p}`: {c} files\n"
+    return section
+
+
+def _generate_advisor_entropy_section(entropy_stats: Dict[str, int]) -> str:
+    """
+    Generates the Directory Entropy section of the Advisor Report.
+    """
+    if not entropy_stats:
+        return ""
+
+    section = "\n## 4. Directory Entropy\n"
+    crowded_dirs = {p: c for p, c in entropy_stats.items() if c > 15}
+    if crowded_dirs:
+        section += _generate_crowded_dirs_list(crowded_dirs)
+    else:
+        section += "✅ Directory structure is balanced.\n"
+    return section
+
+
 def generate_advisor_report(
     stats: Union[List[AdvisorFileResult], List[Dict[str, Any]]],
     dependency_stats: Dict[str, int],
@@ -272,57 +464,8 @@ def generate_advisor_report(
     Generates the advanced Advisor Report based on Agent Physics.
     """
     report = "# 🧠 Agent Readiness Advisor Report\n\nAnalysis based on the **Physics of Agent-Code Interaction**.\n\n"
-
-    # RESOLUTION: Updated Advisor report to reflect high-fidelity ACL formula
-    report += "## 1. Agent Cognitive Load (ACL)\n*Formula: ACL = (Depth * 2) + (Complexity * 1.5) + (LOC / 50)*\n\n"
-
-    high_acl_files = sorted(
-        [s for s in stats if s.get("acl", 0) > 15],
-        key=lambda x: x.get("acl", 0),
-        reverse=True,
-    )
-    if high_acl_files:
-        report += "### 🚨 Hallucination Zones (ACL > 15)\n| File | ACL | Complexity | LOC |\n|---|---|---|---|\n"
-        for s in high_acl_files:
-            report += f"| `{s['file']}` | **{s.get('acl', 0):.1f}** | {s.get('complexity', 0):.1f} | {s.get('loc', 0)} |\n"
-    else:
-        report += "✅ No Hallucination Zones detected.\n"
-
-    report += "\n## 2. Context Economics\n"
-    high_token_files = [f for f in stats if f.get("tokens", 0) > 32000]
-    if high_token_files:
-        report += "### 🪙 Token Budget (> 32k tokens)\n"
-        for f in high_token_files:
-            report += f"- `{f['file']}`: {f.get('tokens', 0)} tokens\n"
-    else:
-        report += "✅ All files within context window limits.\n"
-
-    report += "\n## 3. Dependency Entanglement\n"
-    god_modules = sorted(
-        {k: v for k, v in dependency_stats.items() if v > 50}.items(),
-        key=lambda x: x[1],
-        reverse=True,
-    )
-    if god_modules:
-        report += "### 🕸 God Modules\n| File | Inbound Refs |\n|---|---|\n"
-        for k, v in god_modules:
-            report += f"| `{k}` | {v} |\n"
-
-    if cycles:
-        report += "### 🔄 Circular Dependencies\n"
-        for cycle in cycles:
-            report += f"- {' -> '.join(cycle)} -> {cycle[0]}\n"
-    else:
-        report += "✅ No Circular Dependencies detected.\n"
-
-    if entropy_stats:
-        report += "\n## 4. Directory Entropy\n"
-        crowded_dirs = {p: c for p, c in entropy_stats.items() if c > 15}
-        if crowded_dirs:
-            report += "### 📂 Crowded Directories (> 15 files)\n"
-            for p, c in crowded_dirs.items():
-                report += f"- `{p}`: {c} files\n"
-        else:
-            report += "✅ Directory structure is balanced.\n"
-
+    report += _generate_advisor_acl_section(stats)
+    report += _generate_advisor_tokens_section(stats)
+    report += _generate_advisor_dependency_section(dependency_stats, cycles)
+    report += _generate_advisor_entropy_section(entropy_stats)
     return report


### PR DESCRIPTION
This PR refactors `src/agent_readiness_scorecard/report.py` to address high cognitive load in report generation logic. Functions that previously had "Red" ACL scores (some > 25) have been broken down into smaller units, most achieving ACL scores below 11. This improves both human and AI agent readability of the codebase. All existing tests pass, and output formats remain consistent.

Fixes #323

---
*PR created automatically by Jules for task [11739359621488688066](https://jules.google.com/task/11739359621488688066) started by @brewmarsh*