### PR TITLE
Refactor MarkdownAnalyzer for lower cognitive load

### DIFF
--- a/src/agent_readiness_scorecard/analyzers/markdown.py
+++ b/src/agent_readiness_scorecard/analyzers/markdown.py
@@ -28,42 +28,83 @@ class MarkdownAnalyzer(BaseAnalyzer):
         p_thresholds = profile.get("thresholds", {})
 
         if thresholds is None:
-            thresholds = {
-                "acl_yellow": p_thresholds.get(
-                    "acl_yellow", DEFAULT_THRESHOLDS["acl_yellow"]
-                ),
-                "acl_red": p_thresholds.get("acl_red", DEFAULT_THRESHOLDS["acl_red"]),
-                "token_limit": p_thresholds.get(
-                    "token_limit", DEFAULT_THRESHOLDS["token_limit"]
-                ),
-            }
+            thresholds = self._get_default_thresholds(p_thresholds)
 
         metrics = self.get_function_stats(filepath)
         loc = self._get_loc(filepath)
 
-        score = 100
-        details = []
+        score = 100.0
+        details: List[str] = []
 
-        # Markdown bloat penalty: > 500 lines
+        score, details = self._apply_bloat_penalty(score, details, loc)
+
+        if not metrics:
+            return max(int(score), 0), ", ".join(details), loc, 0.0, 100.0, []
+
+        score, details = self._apply_token_penalty(
+            score, details, cumulative_tokens, thresholds
+        )
+        score, details = self._apply_acl_penalty(score, details, metrics, thresholds)
+
+        # Markdown is always "typed" in this context
+        type_safety_index = 100.0
+        avg_complexity = sum(m["complexity"] for m in metrics) / len(metrics)
+
+        return (
+            max(int(score), 0),
+            ", ".join(details),
+            loc,
+            avg_complexity,
+            type_safety_index,
+            metrics,
+        )
+
+    def _get_default_thresholds(self, p_thresholds: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "acl_yellow": p_thresholds.get(
+                "acl_yellow", DEFAULT_THRESHOLDS["acl_yellow"]
+            ),
+            "acl_red": p_thresholds.get("acl_red", DEFAULT_THRESHOLDS["acl_red"]),
+            "token_limit": p_thresholds.get(
+                "token_limit", DEFAULT_THRESHOLDS["token_limit"]
+            ),
+        }
+
+    def _apply_bloat_penalty(
+        self, score: float, details: List[str], loc: int
+    ) -> Tuple[float, List[str]]:
         if loc > 500:
             bloat_penalty = (loc - 500) // 25
             if bloat_penalty > 0:
                 score -= bloat_penalty
                 details.append(f"Bloated Documentation: {loc} lines (-{bloat_penalty})")
+        return score, details
 
-        if not metrics:
-            return max(score, 0), ", ".join(details), loc, 0.0, 100.0, []
-
-        acl_yellow = thresholds.get("acl_yellow", DEFAULT_THRESHOLDS["acl_yellow"])
-        acl_red = thresholds.get("acl_red", DEFAULT_THRESHOLDS["acl_red"])
+    def _apply_token_penalty(
+        self,
+        score: float,
+        details: List[str],
+        cumulative_tokens: int,
+        thresholds: Dict[str, Any],
+    ) -> Tuple[float, List[str]]:
         token_limit = thresholds.get("token_limit", DEFAULT_THRESHOLDS["token_limit"])
-
         if cumulative_tokens > token_limit:
             penalty = 15
             score -= penalty
             details.append(
                 f"Cumulative Token Budget Exceeded: {cumulative_tokens:,} > {token_limit:,} (-{penalty})"
             )
+        return score, details
+
+    def _apply_acl_penalty(
+        self,
+        score: float,
+        details: List[str],
+        metrics: List[FunctionMetric],
+        thresholds: Dict[str, Any],
+    ) -> Tuple[float, List[str]]:
+        acl_yellow = thresholds.get("acl_yellow", DEFAULT_THRESHOLDS["acl_yellow"])
+        acl_red = thresholds.get("acl_red", DEFAULT_THRESHOLDS["acl_red"])
 
         red_count = sum(1 for m in metrics if m["acl"] > acl_red)
         yellow_count = sum(1 for m in metrics if acl_yellow < m["acl"] <= acl_red)
@@ -81,19 +122,7 @@ class MarkdownAnalyzer(BaseAnalyzer):
             details.append(
                 f"{yellow_count} Yellow ACL sections detected. Consider breaking down large documentation chunks (-{penalty})"
             )
-
-        # Markdown is always "typed" in this context
-        type_safety_index = 100.0
-        avg_complexity = sum(m["complexity"] for m in metrics) / len(metrics)
-
-        return (
-            max(score, 0),
-            ", ".join(details),
-            loc,
-            avg_complexity,
-            type_safety_index,
-            metrics,
-        )
+        return score, details
 
     def get_function_stats(self, filepath: str) -> List[FunctionMetric]:
         """
@@ -108,9 +137,17 @@ class MarkdownAnalyzer(BaseAnalyzer):
         stats: List[FunctionMetric] = []
         enc = tiktoken.get_encoding("cl100k_base")
 
-        sections = []
+        sections = self._parse_sections(lines)
+
+        for header, lineno, content_lines in sections:
+            stats.append(self._analyze_section(header, lineno, content_lines, enc))
+
+        return stats
+
+    def _parse_sections(self, lines: List[str]) -> List[Tuple[str, int, List[str]]]:
+        sections: List[Tuple[str, int, List[str]]] = []
         current_header = None
-        current_content = []
+        current_content: List[str] = []
         header_lineno = 0
 
         for i, line in enumerate(lines):
@@ -134,36 +171,39 @@ class MarkdownAnalyzer(BaseAnalyzer):
         if current_header is not None:
             sections.append((current_header, header_lineno, current_content))
 
-        for header, lineno, content_lines in sections:
-            content = "".join(content_lines)
-            tokens = len(enc.encode(content))
+        return sections
 
-            # Nesting depth is the number of # symbols
-            nesting_depth = 0
-            for char in header:
-                if char == "#":
-                    nesting_depth += 1
-                else:
-                    break
+    def _analyze_section(
+        self, header: str, lineno: int, content_lines: List[str], enc: Any
+    ) -> FunctionMetric:
+        content = "".join(content_lines)
+        tokens = len(enc.encode(content))
 
-            loc = len(content_lines)
-            # ACL = (Header Depth * 1.5) + (Tokens in Section / 100)
-            acl = self.calculate_acl(float(tokens), loc, nesting_depth)
+        nesting_depth = self._get_nesting_depth(header)
+        loc = len(content_lines)
+        # ACL = (Header Depth * 1.5) + (Tokens in Section / 100)
+        acl = self.calculate_acl(float(tokens), loc, nesting_depth)
 
-            stats.append(
-                {
-                    "name": header,
-                    "lineno": lineno,
-                    "complexity": tokens
-                    / 100.0,  # Use token density as complexity for reporting
-                    "loc": loc,
-                    "acl": acl,
-                    "is_typed": True,
-                    "nesting_depth": nesting_depth,
-                }
-            )
+        return {
+            "name": header,
+            "lineno": lineno,
+            "complexity": tokens
+            / 100.0,  # Use token density as complexity for reporting
+            "loc": loc,
+            "acl": acl,
+            "is_typed": True,
+            "nesting_depth": nesting_depth,
+        }
 
-        return stats
+    def _get_nesting_depth(self, header: str) -> int:
+        # Nesting depth is the number of # symbols
+        nesting_depth = 0
+        for char in header:
+            if char == "#":
+                nesting_depth += 1
+            else:
+                break
+        return nesting_depth
 
     def calculate_acl(self, complexity: float, loc: int, depth: int) -> float:
         """


### PR DESCRIPTION
I have refactored `src/agent_readiness_scorecard/analyzers/markdown.py` to address the high cognitive load in the `score_file` and `get_function_stats` functions. 

The logic has been decomposed into several private helper methods:
- `_get_default_thresholds`, `_apply_bloat_penalty`, `_apply_token_penalty`, and `_apply_acl_penalty` for `score_file`.
- `_parse_sections`, `_analyze_section`, and `_get_nesting_depth` for `get_function_stats`.

These changes ensure that all units of code are under 50 lines and maintain an Agent Cognitive Load (ACL) score of less than 10, adhering to the project's maintainability standards. I have verified the changes by running the full test suite, with all 134 tests passing.

Fixes #332

---
*PR created automatically by Jules for task [15554628264727054364](https://jules.google.com/task/15554628264727054364) started by @brewmarsh*