### PR TITLE
Refactor graph.py for lower Agent Cognitive Load (ACL)

### DIFF
--- a/src/agent_readiness_scorecard/graph.py
+++ b/src/agent_readiness_scorecard/graph.py
@@ -4,6 +4,28 @@ from typing import Dict, List, Set, Any
 import networkx as nx
 
 
+def _process_import(node: ast.Import, imports: List[Dict[str, Any]]) -> None:
+    """Helper to process ast.Import nodes."""
+    for n in node.names:
+        imports.append({"module": n.name, "level": 0})
+
+
+def _handle_import_node(node: ast.AST, imports: List[Dict[str, Any]]) -> None:
+    """Helper to process ast.Import and ast.ImportFrom nodes."""
+    if isinstance(node, ast.Import):
+        _process_import(node, imports)
+    elif isinstance(node, ast.ImportFrom):
+        imports.append({"module": node.module, "level": node.level})
+
+
+def _extract_imports_from_ast(tree: ast.AST) -> List[Dict[str, Any]]:
+    """Walks the AST tree to extract imports."""
+    imports: List[Dict[str, Any]] = []
+    for node in ast.walk(tree):
+        _handle_import_node(node, imports)
+    return imports
+
+
 def get_imports(filepath: str) -> List[Dict[str, Any]]:
     """
     Extracts all imports from a python file using AST.
@@ -14,20 +36,64 @@ def get_imports(filepath: str) -> List[Dict[str, Any]]:
     Returns:
         List[Dict[str, Any]]: A list of dictionaries containing 'module' and 'level' for each import.
     """
-    with open(filepath, "r", encoding="utf-8") as f:
-        try:
-            tree = ast.parse(f.read())
-        except SyntaxError:
-            return []
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            content = f.read()
+        tree = ast.parse(content)
+        return _extract_imports_from_ast(tree)
+    except (SyntaxError, FileNotFoundError, UnicodeDecodeError):
+        return []
 
-    imports = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for n in node.names:
-                imports.append({"module": n.name, "level": 0})
-        elif isinstance(node, ast.ImportFrom):
-            imports.append({"module": node.module, "level": node.level})
-    return imports
+
+def _resolve_relative_import(
+    current_file: str, module_name: str, level: int
+) -> str | None:
+    """Resolves target directory for relative imports."""
+    parts = os.path.dirname(current_file).split(os.sep)
+    if level > len(parts):
+        return None
+
+    target_dir = os.sep.join(parts[: len(parts) - (level - 1)])
+    if not module_name:
+        return target_dir
+
+    return os.path.join(target_dir, *module_name.split("."))
+
+
+def _is_matching_py_file(py_file: str, module_path_part: str) -> bool:
+    """Checks if a py_file matches the module path."""
+    is_module = py_file.endswith(module_path_part + ".py")
+    is_pkg = py_file.endswith(os.path.join(module_path_part, "__init__.py"))
+    return is_module or is_pkg
+
+
+def _find_py_file(module_path_part: str, py_files: Set[str]) -> str | None:
+    """Finds a py_file matching the module path part."""
+    for py_file in py_files:
+        if _is_matching_py_file(py_file, module_path_part):
+            return py_file
+    return None
+
+
+def _resolve_absolute_import(module_name: str, py_files: Set[str]) -> str | None:
+    """Resolves absolute imports by heuristic matching against py_files."""
+    if not module_name:
+        return None
+
+    module_path_part = module_name.replace(".", os.sep)
+    return _find_py_file(module_path_part, py_files)
+
+
+def _check_path_existence(target_path: str) -> str | None:
+    """Checks if target_path corresponds to a .py file or a package."""
+    py_file = target_path + ".py"
+    init_file = os.path.join(target_path, "__init__.py")
+
+    if os.path.isfile(py_file):
+        return os.path.abspath(py_file)
+    if os.path.isdir(target_path) and os.path.isfile(init_file):
+        return os.path.abspath(init_file)
+    return None
 
 
 def resolve_module_path(
@@ -47,46 +113,48 @@ def resolve_module_path(
         str | None: The resolved absolute path to the module, or None if not found.
     """
     if level > 0:
-        # Relative import
-        parts = os.path.dirname(current_file).split(os.sep)
-        # level 1 = current dir, level 2 = parent, etc.
-        if level > len(parts):
-            return None
+        target_path = _resolve_relative_import(current_file, module_name, level)
+        return _check_path_existence(target_path) if target_path else None
 
-        target_dir = os.sep.join(parts[: len(parts) - (level - 1)])
+    return _resolve_absolute_import(module_name, py_files)
 
-        if module_name:
-            module_parts = module_name.split(".")
-            target_path = os.path.join(target_dir, *module_parts)
-        else:
-            target_path = target_dir
 
-    else:
-        # Absolute import - this is harder.
-        # We try to match it against our known py_files by checking suffixes.
-        if not module_name:
-            return None
+def _collect_py_file(root: str, file: str, py_files: Set[str]) -> None:
+    """Adds absolute path of .py file to py_files."""
+    if file.endswith(".py"):
+        py_files.add(os.path.abspath(os.path.join(root, file)))
 
-        module_path_part = module_name.replace(".", os.sep)
 
-        # Check if any of our py_files ends with this module path
-        # This is a heuristic.
-        for py_file in py_files:
-            if py_file.endswith(module_path_part + ".py") or py_file.endswith(
-                os.path.join(module_path_part, "__init__.py")
-            ):
-                return py_file
-        return None
+def _walk_and_collect_py_files(abs_root: str, py_files: Set[str]) -> None:
+    """Helper to walk directory and collect .py files."""
+    for root, _, files in os.walk(abs_root):
+        for file in files:
+            _collect_py_file(root, file, py_files)
 
-    # Check for .py or /__init__.py
-    if os.path.isfile(target_path + ".py"):
-        return os.path.abspath(target_path + ".py")
-    if os.path.isdir(target_path) and os.path.isfile(
-        os.path.join(target_path, "__init__.py")
-    ):
-        return os.path.abspath(os.path.join(target_path, "__init__.py"))
 
-    return None
+def _collect_all_py_files(abs_root: str) -> Set[str]:
+    """Recursively finds all Python files in a directory."""
+    py_files = set()
+    if os.path.isfile(abs_root) and abs_root.endswith(".py"):
+        py_files.add(abs_root)
+        return py_files
+
+    _walk_and_collect_py_files(abs_root, py_files)
+    return py_files
+
+
+def _add_file_dependencies_to_graph(
+    graph: nx.DiGraph, filepath: str, abs_root: str, py_files: Set[str]
+) -> None:
+    """Extracts imports from a file and adds edges to the graph."""
+    graph.add_node(filepath)
+    imports = get_imports(filepath)
+    for imp in imports:
+        resolved = resolve_module_path(
+            abs_root, filepath, imp["module"], imp["level"], py_files
+        )
+        if resolved and resolved in py_files and resolved != filepath:
+            graph.add_edge(filepath, resolved)
 
 
 def build_dependency_graph(root_path: str) -> nx.DiGraph:
@@ -100,28 +168,11 @@ def build_dependency_graph(root_path: str) -> nx.DiGraph:
         nx.DiGraph: A NetworkX directed graph where nodes are file paths and edges are dependencies.
     """
     graph: nx.DiGraph = nx.DiGraph()
-    py_files = set()
-
     abs_root = os.path.abspath(root_path)
-
-    if os.path.isfile(abs_root):
-        if abs_root.endswith(".py"):
-            py_files.add(abs_root)
-    else:
-        for root, _, files in os.walk(abs_root):
-            for file in files:
-                if file.endswith(".py"):
-                    py_files.add(os.path.abspath(os.path.join(root, file)))
+    py_files = _collect_all_py_files(abs_root)
 
     for filepath in py_files:
-        graph.add_node(filepath)
-        imports = get_imports(filepath)
-        for imp in imports:
-            resolved = resolve_module_path(
-                abs_root, filepath, imp["module"], imp["level"], py_files
-            )
-            if resolved and resolved in py_files and resolved != filepath:
-                graph.add_edge(filepath, resolved)
+        _add_file_dependencies_to_graph(graph, filepath, abs_root, py_files)
 
     return graph
 


### PR DESCRIPTION
The `src/agent_readiness_scorecard/graph.py` module was identified as having high cognitive load (Red ACL scores). This PR refactors the primary functions (`get_imports`, `resolve_module_path`, `build_dependency_graph`) into smaller, modular private helper functions. 

Key changes:
- Logic for AST traversal and import node processing is now separated.
- Module path resolution for both relative and absolute imports is decomposed into discrete steps (matching, existence checking, etc.).
- File collection and graph construction are separated into dedicated helpers.
- All functions now meet the maintainability target of ACL < 10 and < 50 lines of code.
- Robustness is improved with better exception handling during file parsing.

Verification:
- Existing tests in `tests/test_graph.py` pass.
- `agent-score` CLI confirms 100/100 score for `graph.py`.

Fixes #334

---
*PR created automatically by Jules for task [13431460773548692607](https://jules.google.com/task/13431460773548692607) started by @brewmarsh*